### PR TITLE
feat: URL navigation and history commands (Issue #8)

### DIFF
--- a/.claude/specs/url-navigation/design.md
+++ b/.claude/specs/url-navigation/design.md
@@ -1,0 +1,403 @@
+# Design: URL Navigation
+
+**Issue**: #8
+**Date**: 2026-02-11
+**Status**: Draft
+**Author**: Claude (spec-driven development)
+
+---
+
+## Overview
+
+This feature implements the `navigate` subcommand group (`<URL>`, `back`, `forward`, `reload`) by introducing session-level CDP communication to chrome-cli. Unlike `tabs`, which uses browser-level `CdpClient::send_command()` for Target domain operations, navigation requires attaching to a specific tab target via `CdpSession` and enabling the Page and Network domains.
+
+The key technical challenge is implementing wait strategies — configurable policies that determine when a navigation is "complete." These use CDP event subscriptions (`CdpSession::subscribe()`) to listen for `Page.loadEventFired`, `Page.domContentEventFired`, and network activity events. The network idle strategy introduces in-flight request tracking with a 500ms quiescence window.
+
+The implementation follows the established binary-crate command module pattern from `tabs.rs`: a new `src/navigate.rs` module with command handlers, CLI arg types added to `src/cli/mod.rs`, and dispatch wired in `src/main.rs`.
+
+---
+
+## Architecture
+
+### Component Diagram
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│                         CLI Layer                                 │
+│  cli/mod.rs: NavigateArgs, NavigateCommand enum                   │
+│  (Url, Back, Forward, Reload) with per-subcommand args            │
+└────────────────────────────────┬─────────────────────────────────┘
+                                 │
+                                 ▼
+┌──────────────────────────────────────────────────────────────────┐
+│                      Command Layer                                │
+│  navigate.rs: execute_navigate() dispatches to                    │
+│  execute_url(), execute_back(), execute_forward(),                │
+│  execute_reload()                                                 │
+│                                                                   │
+│  Wait strategies (WaitStrategy enum):                             │
+│  - wait_for_load()           → Page.loadEventFired                │
+│  - wait_for_dom_content()    → Page.domContentEventFired          │
+│  - wait_for_network_idle()   → Network.* events + 500ms timer     │
+│  - none                      → return immediately                 │
+└─────────────────┬──────────────────────┬────────────────────────┘
+                  │                      │
+          ┌───────▼───────┐     ┌────────▼────────┐
+          │  Connection   │     │  CDP Session     │
+          │  Layer        │     │  (Page + Network │
+          │  resolve_     │     │   domains)       │
+          │  connection() │     │  ManagedSession  │
+          │  resolve_     │     │  subscribe()     │
+          │  target()     │     │  send_command()  │
+          └───────┬───────┘     └────────┬────────┘
+                  │                      │
+                  └──────────┬───────────┘
+                             ▼
+                   Chrome Browser (CDP)
+```
+
+### Data Flow
+
+#### `navigate <URL>`
+
+```
+1. Parse CLI args (url, --wait-until, --timeout, --ignore-cache, --tab)
+2. resolve_connection(host, port, ws_url) → ResolvedConnection
+3. resolve_target(host, port, tab) → TargetInfo
+4. CdpClient::connect(ws_url) → CdpClient
+5. client.create_session(target_id) → CdpSession
+6. ManagedSession::new(session)
+7. managed.ensure_domain("Page")
+8. managed.ensure_domain("Network") — only if wait=networkidle or need status
+9. Subscribe to wait events BEFORE sending Page.navigate
+10. session.send_command("Page.navigate", {url, ..}) → check errorText
+11. If errorText present → return navigation error (DNS, SSL, etc.)
+12. Wait for strategy events with timeout:
+    - load: Page.loadEventFired
+    - domcontentloaded: Page.domContentEventFired
+    - networkidle: 0 in-flight requests for 500ms
+    - none: skip waiting
+13. Collect Network.responseReceived for main frame → HTTP status
+14. Query page state: Runtime.evaluate("document.title") for title, use navigated URL
+15. Return JSON: {url, title, status}
+```
+
+#### `navigate back`
+
+```
+1. Parse CLI args (--tab)
+2. resolve_connection → resolve_target → create session
+3. managed.ensure_domain("Page")
+4. session.send_command("Page.getNavigationHistory") → {currentIndex, entries}
+5. If currentIndex == 0 → already at start, return current page info
+6. entry = entries[currentIndex - 1]
+7. Subscribe to Page.loadEventFired
+8. session.send_command("Page.navigateToHistoryEntry", {entryId: entry.id})
+9. Wait for Page.loadEventFired with timeout
+10. Return JSON: {url, title}
+```
+
+#### `navigate forward`
+
+```
+1. Same as back, but navigate to entries[currentIndex + 1]
+2. If currentIndex == entries.len() - 1 → already at end, return current page info
+```
+
+#### `navigate reload`
+
+```
+1. Parse CLI args (--ignore-cache, --tab)
+2. resolve_connection → resolve_target → create session
+3. managed.ensure_domain("Page")
+4. Subscribe to Page.loadEventFired
+5. session.send_command("Page.reload", {ignoreCache})
+6. Wait for Page.loadEventFired with timeout
+7. Get current URL and title via Runtime.evaluate
+8. Return JSON: {url, title}
+```
+
+---
+
+## API / Interface Changes
+
+### CLI Subcommand Structure
+
+The `Navigate` variant in the `Command` enum changes from a unit variant to `Navigate(NavigateArgs)` with nested subcommands. Since `navigate <URL>` should also work (not just `navigate url <URL>`), the URL subcommand is the default (no subcommand keyword needed).
+
+| Subcommand | Args | Description |
+|------------|------|-------------|
+| `navigate <URL>` | `--wait-until <EVENT>`, `--timeout <MS>`, `--ignore-cache`, `--tab <ID>` | Navigate to URL |
+| `navigate back` | `--tab <ID>` | Go back in history |
+| `navigate forward` | `--tab <ID>` | Go forward in history |
+| `navigate reload` | `--ignore-cache`, `--tab <ID>` | Reload current page |
+
+**Clap design**: Use `#[command(subcommand)]` with an enum that has `Back`, `Forward`, `Reload` variants, and a catch-all `Url(NavigateUrlArgs)` variant using `#[command(external_subcommand)]` or by making the URL a default subcommand. The simplest approach: make `NavigateCommand` an enum where `Url` is the variant for URL navigation, but use clap's default subcommand feature or restructure so `navigate <URL>` works without a subcommand keyword.
+
+**Recommended approach**: Use `clap::Subcommand` with the URL variant having `#[command(name = "to")]` or make the URL positional on the parent `NavigateArgs` using a flattened approach. After examining clap's capabilities, the cleanest pattern is:
+
+```rust
+pub enum NavigateCommand {
+    /// Navigate back in browser history
+    Back,
+    /// Navigate forward in browser history
+    Forward,
+    /// Reload the current page
+    Reload(NavigateReloadArgs),
+}
+
+pub struct NavigateArgs {
+    /// URL to navigate to (omit for back/forward/reload subcommands)
+    pub url: Option<String>,
+    /// Subcommand (back, forward, reload)
+    pub command: Option<NavigateCommand>,
+    // ... shared flags
+}
+```
+
+However, clap doesn't natively support "optional subcommand with fallback to positional." The cleanest approach that avoids user confusion: keep all four as explicit subcommands but make the URL one named `to`:
+
+- `chrome-cli navigate to <URL>` — but the issue says `chrome-cli navigate <URL>`
+
+**Final approach**: Use a flat argument structure with mutual exclusion:
+
+```rust
+pub struct NavigateArgs {
+    /// URL to navigate to
+    pub url: Option<String>,
+    /// Navigate back in browser history
+    #[arg(long)]
+    pub back: bool,
+    /// Navigate forward in browser history
+    #[arg(long)]
+    pub forward: bool,
+    /// Reload the current page
+    #[arg(long)]
+    pub reload: bool,
+    // ... other flags
+}
+```
+
+Wait — the issue specifies `navigate back`, `navigate forward`, `navigate reload` as subcommands (not flags). Let me reconsider.
+
+**Adopted approach**: Use clap subcommands where `Back`, `Forward`, `Reload` are subcommand variants. For URL navigation without a subcommand keyword, we put the URL as an optional positional arg on the parent `NavigateArgs` and dispatch based on whether a subcommand or positional URL is present. Clap supports this with `#[command(args_conflicts_with_subcommands = true)]`.
+
+```rust
+#[derive(Args)]
+#[command(args_conflicts_with_subcommands = true)]
+pub struct NavigateArgs {
+    #[command(subcommand)]
+    pub command: Option<NavigateCommand>,
+    #[command(flatten)]
+    pub url_args: Option<NavigateUrlArgs>,
+}
+```
+
+This allows both `chrome-cli navigate https://example.com` and `chrome-cli navigate back`.
+
+### Output Schemas
+
+#### `navigate <URL>` (JSON)
+
+```json
+{
+  "url": "https://example.com/",
+  "title": "Example Domain",
+  "status": 200
+}
+```
+
+#### `navigate back` / `navigate forward` / `navigate reload` (JSON)
+
+```json
+{
+  "url": "https://example.com/",
+  "title": "Example Domain"
+}
+```
+
+### Error Responses
+
+All errors use the existing `AppError` JSON format: `{"error": "message", "code": N}`
+
+| Condition | Exit Code | Message |
+|-----------|-----------|---------|
+| No Chrome connection | 2 | "No Chrome instance found..." |
+| Tab not found | 3 | "Tab 'X' not found..." |
+| DNS resolution failure | 1 | "Navigation failed: net::ERR_NAME_NOT_RESOLVED" |
+| SSL error | 1 | "Navigation failed: net::ERR_CERT_..." |
+| Navigation timeout | 4 | "Navigation timed out after Xms waiting for {strategy}" |
+| Already at history start (back) | 0 | Returns current page info (no-op, not an error) |
+| Already at history end (forward) | 0 | Returns current page info (no-op, not an error) |
+
+---
+
+## CDP Commands Used
+
+| Operation | CDP Method | Domain | Level | Parameters |
+|-----------|-----------|--------|-------|------------|
+| Navigate to URL | `Page.navigate` | Page | Session | `url: String`, `transitionType?: String` |
+| Get history | `Page.getNavigationHistory` | Page | Session | None |
+| Navigate to history entry | `Page.navigateToHistoryEntry` | Page | Session | `entryId: i64` |
+| Reload page | `Page.reload` | Page | Session | `ignoreCache?: bool` |
+| Enable Page domain | `Page.enable` | Page | Session | None |
+| Enable Network domain | `Network.enable` | Network | Session | None |
+| Get page title | `Runtime.evaluate` | Runtime | Session | `expression: "document.title"` |
+
+### CDP Events Consumed
+
+| Event | Domain | Used By |
+|-------|--------|---------|
+| `Page.loadEventFired` | Page | `load` wait strategy |
+| `Page.domContentEventFired` | Page | `domcontentloaded` wait strategy |
+| `Network.requestWillBeSent` | Network | `networkidle` (increment in-flight count) |
+| `Network.loadingFinished` | Network | `networkidle` (decrement in-flight count) |
+| `Network.loadingFailed` | Network | `networkidle` (decrement in-flight count) |
+| `Network.responseReceived` | Network | HTTP status extraction for main frame |
+
+---
+
+## Wait Strategy Implementation
+
+### Wait for Load
+
+```
+1. Subscribe to Page.loadEventFired via session.subscribe()
+2. Send Page.navigate
+3. tokio::select! {
+     event = rx.recv() => Ok(()),
+     _ = tokio::time::sleep(timeout) => Err(timeout)
+   }
+```
+
+### Wait for DOMContentLoaded
+
+Same as load, but subscribes to `Page.domContentEventFired`.
+
+### Wait for Network Idle
+
+```
+1. Subscribe to Network.requestWillBeSent, Network.loadingFinished, Network.loadingFailed
+2. Track in_flight_count: u32 = 0
+3. Send Page.navigate
+4. Loop:
+   tokio::select! {
+     event = request_rx.recv() => { in_flight_count += 1; reset idle timer }
+     event = finished_rx.recv() => { in_flight_count = in_flight_count.saturating_sub(1); if 0, start 500ms idle timer }
+     event = failed_rx.recv() => { in_flight_count = in_flight_count.saturating_sub(1); if 0, start 500ms idle timer }
+     _ = idle_timer (500ms) => { if in_flight_count == 0, break Ok(()) }
+     _ = overall_timeout => { break Err(timeout) }
+   }
+```
+
+### Wait for None
+
+Return immediately after `Page.navigate` completes (the CDP command response itself).
+
+---
+
+## HTTP Status Code Extraction
+
+To get the HTTP status code of the main document:
+
+1. Enable the Network domain before navigation
+2. Subscribe to `Network.responseReceived`
+3. After `Page.navigate`, the first `Network.responseReceived` event where `type == "Document"` contains `response.status`
+4. Store the status code and include it in the output
+
+If Network events are unavailable (e.g., cached page), default to status 0 or omit the field.
+
+---
+
+## Module Structure
+
+### New Files
+
+| File | Purpose |
+|------|---------|
+| `src/navigate.rs` | Navigate command handlers: `execute_navigate()`, plus internal functions for URL/back/forward/reload and wait strategies |
+
+### Modified Files
+
+| File | Change |
+|------|--------|
+| `src/cli/mod.rs` | Change `Navigate` from unit variant to `Navigate(NavigateArgs)` with nested `NavigateCommand` enum, add `NavigateUrlArgs`, `NavigateReloadArgs`, `WaitUntil` enum |
+| `src/main.rs` | Update match arm from `Command::Navigate => not_implemented()` to dispatch to `navigate::execute_navigate()`, add `mod navigate;` |
+| `src/error.rs` | Add `AppError::navigation_failed()` and `AppError::navigation_timeout()` constructors |
+
+### Unchanged Files
+
+| File | Why Unchanged |
+|------|---------------|
+| `src/lib.rs` | Navigate handlers are CLI-specific orchestration in the binary crate |
+| `src/connection.rs` | Existing `resolve_connection()`, `resolve_target()`, `ManagedSession` are reused as-is |
+| `src/cdp/*` | CdpClient, CdpSession, and subscribe() APIs are sufficient |
+| `src/tabs.rs` | No interaction with tab management |
+
+---
+
+## Alternatives Considered
+
+| Option | Description | Pros | Cons | Decision |
+|--------|-------------|------|------|----------|
+| **A: Browser-level commands only** | Use `Page.navigate` via browser-level `CdpClient` | No session needed | Cannot subscribe to per-tab events; Page domain requires session attachment | Rejected — wait strategies require session |
+| **B: JavaScript-based navigation** | Use `Runtime.evaluate("location.href = ...")` | Works without Page domain | No wait strategy, no errorText for DNS/SSL, no status code | Rejected — inferior error handling |
+| **C: Session-level with ManagedSession** | Attach to target, enable domains lazily, use event subscriptions | Full CDP capabilities, proper error handling, wait strategies work | More complex setup (attach + enable) | **Selected** — necessary for requirements |
+| **D: Flag-based subcommands** | `navigate --back`, `navigate --forward` instead of subcommands | Simpler clap structure | Against issue spec; `navigate back` reads better | Rejected — issue specifies subcommands |
+| **E: Separate wait module in lib.rs** | Put wait strategy logic in a reusable library module | Reusable by future commands (e.g., `page screenshot` may also wait) | Over-engineering for now; can extract later | Rejected — YAGNI, keep in navigate.rs for now |
+
+---
+
+## Security Considerations
+
+- [x] **Input Validation**: URLs are forwarded to Chrome as-is; Chrome handles URL validation and security (blocks `javascript:`, `data:` with cross-origin restrictions, etc.)
+- [x] **Local-only**: Inherits `warn_if_remote_host()` behavior from connection resolution
+- [x] **No secrets**: No credentials or tokens stored or transmitted
+- [x] **No arbitrary code execution**: Navigation commands do not execute user-supplied JavaScript (that's the `js` command)
+
+---
+
+## Performance Considerations
+
+- [x] **Session reuse**: Each navigate command creates one CdpSession per invocation (stateless CLI design)
+- [x] **Event subscription setup**: Subscribe to events BEFORE sending navigation to avoid race conditions
+- [x] **Network idle efficiency**: Uses CDP events (push) rather than polling; 500ms idle window is standard (matches Puppeteer)
+- [x] **Domain enabling**: ManagedSession avoids redundant `{domain}.enable` calls within a single command
+- [x] **Timeout**: Configurable via `--timeout`, defaults to 30s, applies to wait strategy not CDP transport
+
+---
+
+## Testing Strategy
+
+| Layer | Type | Coverage |
+|-------|------|----------|
+| Unit | `#[test]` in `src/navigate.rs` | WaitUntil parsing, error message formatting, history navigation edge cases (at start/end) |
+| Unit | `#[test]` in `src/error.rs` | New error constructors |
+| Unit | `#[test]` in `src/cli/mod.rs` | Clap arg parsing for NavigateCommand variants |
+| Integration (BDD) | `tests/features/url-navigation.feature` | All 18 acceptance criteria |
+
+---
+
+## Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Race between subscribe and navigate | Medium | High | Always subscribe BEFORE sending Page.navigate; CDP buffers events per session |
+| Network idle never stabilizes (long-polling, WebSockets) | Medium | Medium | Overall timeout prevents hang; 500ms window is pragmatic |
+| `Page.navigate` errorText format changes across Chrome versions | Low | Low | Use substring matching for common errors (net::ERR_*) |
+| History navigation entry IDs not stable | Low | Low | Get fresh history before each back/forward; no caching |
+| `Runtime.evaluate` for title fails if page is error page | Low | Low | Default to empty string on evaluation failure |
+
+---
+
+## Validation Checklist
+
+- [x] Architecture follows existing project patterns (per `structure.md`)
+- [x] All API/interface changes documented with schemas
+- [x] No database/storage changes needed
+- [x] State management: stateless CLI, no local state beyond session file
+- [x] Security considerations addressed
+- [x] Performance impact analyzed
+- [x] Testing strategy defined
+- [x] Alternatives were considered and documented
+- [x] Risks identified with mitigations

--- a/.claude/specs/url-navigation/feature.gherkin
+++ b/.claude/specs/url-navigation/feature.gherkin
@@ -1,0 +1,160 @@
+# File: tests/features/url-navigation.feature
+#
+# Generated from: .claude/specs/url-navigation/requirements.md
+# Issue: #8
+
+Feature: URL Navigation
+  As a developer or automation engineer
+  I want to navigate Chrome to URLs and traverse browser history from the CLI
+  So that I can script browser navigation workflows without manual interaction
+
+  Background:
+    Given Chrome is running with CDP enabled
+
+  # --- URL Navigation: Happy Path ---
+
+  Scenario: AC1 - Navigate to a valid URL
+    Given a tab is open with "about:blank"
+    When I run "chrome-cli navigate https://example.com"
+    Then the exit code is 0
+    And the JSON output has key "url" containing "example.com"
+    And the JSON output has key "title" with a non-empty string
+    And the JSON output has key "status" with a numeric value
+
+  Scenario: AC2 - Navigate with --tab to target a specific tab
+    Given two tabs are open
+    And the second tab has ID "<TAB_ID>"
+    When I run "chrome-cli navigate https://example.com --tab <TAB_ID>"
+    Then the exit code is 0
+    And the JSON output has key "url" containing "example.com"
+    And the first tab URL is unchanged
+
+  # --- Wait Strategies ---
+
+  Scenario: AC3 - Navigate with --wait-until load (default)
+    Given a tab is open
+    When I run "chrome-cli navigate https://example.com --wait-until load"
+    Then the exit code is 0
+    And the command waited for the page load event
+    And the JSON output has key "url"
+    And the JSON output has key "title"
+    And the JSON output has key "status"
+
+  Scenario: AC4 - Navigate with --wait-until domcontentloaded
+    Given a tab is open
+    When I run "chrome-cli navigate https://example.com --wait-until domcontentloaded"
+    Then the exit code is 0
+    And the command returned after DOMContentLoaded fired
+    And the JSON output has key "url"
+    And the JSON output has key "title"
+    And the JSON output has key "status"
+
+  Scenario: AC5 - Navigate with --wait-until networkidle
+    Given a tab is open
+    When I run "chrome-cli navigate https://example.com --wait-until networkidle"
+    Then the exit code is 0
+    And the command waited until network was idle for 500ms
+    And the JSON output has key "url"
+    And the JSON output has key "title"
+    And the JSON output has key "status"
+
+  Scenario: AC6 - Navigate with --wait-until none
+    Given a tab is open
+    When I run "chrome-cli navigate https://example.com --wait-until none"
+    Then the exit code is 0
+    And the command returned immediately after initiating navigation
+    And the JSON output has key "url"
+
+  # --- Timeout ---
+
+  Scenario: AC7 - Navigate with --timeout
+    Given a tab is open
+    When I run "chrome-cli navigate https://httpbin.org/delay/60 --timeout 1000"
+    Then the exit code is 4
+    And the error message contains "timed out"
+    And the error message contains "1000ms"
+
+  # --- Cache Bypass ---
+
+  Scenario: AC8 - Navigate with --ignore-cache
+    Given a tab is open
+    When I run "chrome-cli navigate https://example.com --ignore-cache"
+    Then the exit code is 0
+    And the navigation bypassed the browser cache
+    And the JSON output has key "url"
+
+  # --- History: Back ---
+
+  Scenario: AC9 - Navigate back in browser history
+    Given a tab is open with "https://example.com"
+    And the tab has navigated to "https://www.iana.org/domains/reserved"
+    When I run "chrome-cli navigate back"
+    Then the exit code is 0
+    And the JSON output has key "url" containing "example.com"
+    And the JSON output has key "title"
+
+  Scenario: AC10 - Navigate back with --tab
+    Given two tabs are open
+    And the second tab has navigated to two pages
+    When I run "chrome-cli navigate back --tab <TAB_ID>"
+    Then the exit code is 0
+    And the JSON output has key "url"
+    And the specified tab navigated back
+
+  # --- History: Forward ---
+
+  Scenario: AC11 - Navigate forward in browser history
+    Given a tab has navigated to two pages and then gone back
+    When I run "chrome-cli navigate forward"
+    Then the exit code is 0
+    And the JSON output has key "url" containing the second page URL
+    And the JSON output has key "title"
+
+  Scenario: AC12 - Navigate forward with --tab
+    Given two tabs are open
+    And the second tab has gone back and has forward history
+    When I run "chrome-cli navigate forward --tab <TAB_ID>"
+    Then the exit code is 0
+    And the specified tab navigated forward
+
+  # --- Reload ---
+
+  Scenario: AC13 - Reload the current page
+    Given a tab is open with "https://example.com"
+    When I run "chrome-cli navigate reload"
+    Then the exit code is 0
+    And the JSON output has key "url" containing "example.com"
+    And the JSON output has key "title"
+
+  Scenario: AC14 - Reload with --ignore-cache
+    Given a tab is open with "https://example.com"
+    When I run "chrome-cli navigate reload --ignore-cache"
+    Then the exit code is 0
+    And the page was reloaded bypassing the cache
+
+  Scenario: AC15 - Reload with --tab
+    Given two tabs are open with pages loaded
+    When I run "chrome-cli navigate reload --tab <TAB_ID>"
+    Then the exit code is 0
+    And the specified tab was reloaded
+
+  # --- Error Handling ---
+
+  Scenario: AC16 - DNS resolution failure
+    Given a tab is open
+    When I run "chrome-cli navigate https://this-domain-does-not-exist.invalid"
+    Then the exit code is not 0
+    And the error message contains "Navigation failed"
+    And the error message contains "ERR_NAME_NOT_RESOLVED" or a DNS-related message
+
+  Scenario: AC17 - Navigation timeout
+    Given a tab is open
+    When I run "chrome-cli navigate https://httpbin.org/delay/60 --timeout 1000"
+    Then the exit code is 4
+    And the error message contains "timed out"
+
+  Scenario: AC18 - No Chrome connection
+    Given no Chrome instance is running
+    When I run "chrome-cli navigate https://example.com"
+    Then the exit code is 2
+    And the error message contains "No Chrome instance found" or "chrome-cli connect"

--- a/.claude/specs/url-navigation/requirements.md
+++ b/.claude/specs/url-navigation/requirements.md
@@ -1,0 +1,309 @@
+# Requirements: URL Navigation
+
+**Issue**: #8
+**Date**: 2026-02-11
+**Status**: Draft
+**Author**: Claude (spec-driven development)
+
+---
+
+## User Story
+
+**As a** developer or automation engineer
+**I want** to navigate Chrome to URLs, reload pages, and traverse browser history from the command line
+**So that** I can script browser navigation workflows without manual interaction
+
+---
+
+## Background
+
+The `navigate` subcommand group implements URL navigation and browser history traversal for chrome-cli. This maps to the MCP server's `navigate_page` tool, which supports URL navigation, back/forward/reload, and configurable wait strategies. The navigate feature is a core MVP capability — it enables the fundamental "go to a URL and wait for it to load" workflow that underpins all other page inspection and interaction commands.
+
+Navigation requires session-level CDP communication (attached to a specific tab target) because the Page and Network domains are per-target, unlike the browser-level Target domain commands used by `tabs`. This introduces the first use of `CdpSession`, `ManagedSession`, and event subscriptions in the command layer.
+
+---
+
+## Acceptance Criteria
+
+### AC1: Navigate to a valid URL
+
+**Given** Chrome is running with CDP enabled and a tab is open
+**When** I run `chrome-cli navigate https://example.com`
+**Then** the active tab navigates to `https://example.com`
+**And** the command waits for the `load` event (default wait strategy)
+**And** the output is JSON: `{"url": "https://example.com/", "title": "Example Domain", "status": 200}`
+**And** the exit code is 0
+
+### AC2: Navigate with --tab to target a specific tab
+
+**Given** Chrome has multiple tabs open
+**When** I run `chrome-cli navigate https://example.com --tab <ID>`
+**Then** the specified tab navigates to the URL
+**And** other tabs are unaffected
+
+### AC3: Navigate with --wait-until load (default)
+
+**Given** Chrome is running with a tab open
+**When** I run `chrome-cli navigate https://example.com --wait-until load`
+**Then** the command waits for `Page.loadEventFired` before returning
+**And** the JSON output includes the final URL, title, and HTTP status
+
+### AC4: Navigate with --wait-until domcontentloaded
+
+**Given** Chrome is running with a tab open
+**When** I run `chrome-cli navigate https://example.com --wait-until domcontentloaded`
+**Then** the command waits for `Page.domContentEventFired` before returning
+**And** the JSON output includes the final URL, title, and HTTP status
+
+### AC5: Navigate with --wait-until networkidle
+
+**Given** Chrome is running with a tab open
+**When** I run `chrome-cli navigate https://example.com --wait-until networkidle`
+**Then** the command waits until there are 0 in-flight network requests for 500ms
+**And** the JSON output includes the final URL, title, and HTTP status
+
+### AC6: Navigate with --wait-until none
+
+**Given** Chrome is running with a tab open
+**When** I run `chrome-cli navigate https://example.com --wait-until none`
+**Then** the command returns immediately after initiating navigation
+**And** the JSON output includes the URL that was navigated to
+
+### AC7: Navigate with --timeout
+
+**Given** Chrome is running with a tab open
+**When** I run `chrome-cli navigate https://example.com --timeout 5000`
+**Then** the navigation timeout is set to 5000ms
+**And** if the wait strategy does not complete within 5000ms, the command fails with exit code 4
+
+### AC8: Navigate with --ignore-cache
+
+**Given** Chrome is running with a tab open
+**When** I run `chrome-cli navigate https://example.com --ignore-cache`
+**Then** the navigation bypasses the browser cache
+**And** the page is fetched fresh from the server
+
+### AC9: Navigate back in browser history
+
+**Given** Chrome has navigated to at least two pages in the active tab
+**When** I run `chrome-cli navigate back`
+**Then** the tab navigates back one step in history
+**And** the output is JSON with the new URL and title
+**And** the exit code is 0
+
+### AC10: Navigate back with --tab
+
+**Given** Chrome has multiple tabs, and a specific tab has history
+**When** I run `chrome-cli navigate back --tab <ID>`
+**Then** the specified tab navigates back in its history
+
+### AC11: Navigate forward in browser history
+
+**Given** Chrome has navigated back from a page
+**When** I run `chrome-cli navigate forward`
+**Then** the tab navigates forward one step in history
+**And** the output is JSON with the new URL and title
+**And** the exit code is 0
+
+### AC12: Navigate forward with --tab
+
+**Given** Chrome has multiple tabs, and a specific tab has forward history
+**When** I run `chrome-cli navigate forward --tab <ID>`
+**Then** the specified tab navigates forward in its history
+
+### AC13: Reload the current page
+
+**Given** Chrome has a page loaded in the active tab
+**When** I run `chrome-cli navigate reload`
+**Then** the page reloads
+**And** the output is JSON with the URL and title
+**And** the exit code is 0
+
+### AC14: Reload with --ignore-cache
+
+**Given** Chrome has a page loaded in the active tab
+**When** I run `chrome-cli navigate reload --ignore-cache`
+**Then** the page performs a hard reload, bypassing the cache
+
+### AC15: Reload with --tab
+
+**Given** Chrome has multiple tabs with pages loaded
+**When** I run `chrome-cli navigate reload --tab <ID>`
+**Then** the specified tab reloads
+
+### AC16: DNS resolution failure
+
+**Given** Chrome is running with a tab open
+**When** I run `chrome-cli navigate https://this-domain-does-not-exist.invalid`
+**Then** the command fails with a meaningful error message mentioning DNS resolution
+**And** the exit code is non-zero
+
+### AC17: Navigation timeout
+
+**Given** Chrome is running with a tab open
+**When** I run `chrome-cli navigate https://httpbin.org/delay/60 --timeout 1000`
+**Then** the command fails with a timeout error message
+**And** the exit code is 4
+
+### AC18: No Chrome connection
+
+**Given** no Chrome instance is running or connected
+**When** I run `chrome-cli navigate https://example.com`
+**Then** the command fails with exit code 2
+**And** the error message suggests running `chrome-cli connect`
+
+### Generated Gherkin Preview
+
+```gherkin
+Feature: URL Navigation
+  As a developer or automation engineer
+  I want to navigate Chrome to URLs and traverse browser history
+  So that I can script browser navigation workflows
+
+  Background:
+    Given Chrome is running with CDP enabled
+
+  Scenario: Navigate to a valid URL
+    Given a tab is open
+    When I run "chrome-cli navigate https://example.com"
+    Then the output JSON has key "url" with value "https://example.com/"
+    And the output JSON has key "title"
+    And the output JSON has key "status" with a numeric value
+    And the exit code is 0
+
+  Scenario: Navigate with --tab targets specific tab
+    Given multiple tabs are open
+    When I run "chrome-cli navigate https://example.com --tab <ID>"
+    Then the specified tab URL changes to "https://example.com/"
+
+  Scenario: Wait until load (default)
+    ...
+
+  Scenario: Wait until domcontentloaded
+    ...
+
+  # ... remaining scenarios
+```
+
+---
+
+## Functional Requirements
+
+| ID | Requirement | Priority | Notes |
+|----|-------------|----------|-------|
+| FR1 | `navigate <URL>` navigates the active or specified tab to a URL | Must | Core navigation |
+| FR2 | `--wait-until` supports `load`, `domcontentloaded`, `networkidle`, `none` | Must | Default: `load` |
+| FR3 | `--timeout` sets navigation timeout in milliseconds | Must | Default: 30000ms |
+| FR4 | `--ignore-cache` bypasses browser cache during navigation | Must | |
+| FR5 | `--tab <ID>` targets a specific tab by ID or index | Must | Uses existing `select_target()` |
+| FR6 | `navigate back` goes back one step in browser history | Must | Via `Page.navigateToHistoryEntry` or JS `history.back()` |
+| FR7 | `navigate forward` goes forward one step in browser history | Must | Via `Page.navigateToHistoryEntry` or JS `history.forward()` |
+| FR8 | `navigate reload` reloads the current page | Must | Via `Page.reload` |
+| FR9 | `reload --ignore-cache` performs a hard reload | Must | `Page.reload` with `ignoreCache: true` |
+| FR10 | JSON output includes `url`, `title`, and `status` (for URL navigation) | Must | Status from `Page.frameNavigated` or navigate response |
+| FR11 | JSON output includes `url` and `title` for back/forward/reload | Must | |
+| FR12 | Network idle detection: 0 in-flight requests for 500ms | Should | Track via Network.requestWillBeSent / loadingFinished / loadingFailed |
+| FR13 | Meaningful error messages for DNS failures | Should | Parse `Page.navigate` errorText |
+| FR14 | Meaningful error messages for SSL errors | Should | Parse `Page.navigate` errorText |
+| FR15 | Global `--tab` flag also works for navigate commands | Must | Consistent with tabs command |
+
+---
+
+## Non-Functional Requirements
+
+| Aspect | Requirement |
+|--------|-------------|
+| **Performance** | Navigation commands should add minimal overhead beyond Chrome's own load time |
+| **Reliability** | Wait strategies must handle edge cases (pages that never fire load, infinite redirects) via timeout |
+| **Platforms** | macOS, Linux, Windows — all via CDP, no platform-specific code needed |
+| **Error handling** | All CDP errors converted to AppError with appropriate exit codes |
+
+---
+
+## Data Requirements
+
+### Input Data
+
+| Field | Type | Validation | Required |
+|-------|------|------------|----------|
+| url | String | Must be a URL (Chrome validates) | Yes (for `navigate <URL>`) |
+| --tab | String | Tab ID or numeric index | No (defaults to active tab) |
+| --wait-until | Enum | One of: load, domcontentloaded, networkidle, none | No (default: load) |
+| --timeout | u64 | Positive integer, milliseconds | No (default: 30000) |
+| --ignore-cache | bool | Flag | No (default: false) |
+
+### Output Data
+
+#### URL Navigation (`navigate <URL>`)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| url | String | The final URL after navigation (may differ from input due to redirects) |
+| title | String | Page title after navigation |
+| status | u16 | HTTP response status code |
+
+#### History Navigation (`navigate back`, `navigate forward`, `navigate reload`)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| url | String | The URL after navigation |
+| title | String | Page title after navigation |
+
+---
+
+## Dependencies
+
+### Internal Dependencies
+- [x] CDP client (Issue #4) — CdpClient, CdpSession, event subscriptions
+- [x] Session/connection management (Issue #6) — resolve_connection, ManagedSession, select_target
+- [x] Tab management (Issue #7) — establishes command module pattern
+
+### External Dependencies
+- [x] Chrome DevTools Protocol — Page domain, Network domain
+
+### Blocked By
+- [x] Issue #4 (CDP client) — Completed
+- [x] Issue #6 (Session management) — Completed
+
+---
+
+## Out of Scope
+
+- **Script injection before/after navigation** — will be handled by the `js` command
+- **Network request interception** — will be handled by the `network` command
+- **Unload handling / beforeunload dialogs** — deferred to a later issue
+- **Multiple URL navigation in sequence** — users can call the command multiple times
+- **Custom referrer or extra headers** — deferred to a later issue
+- **Navigation to `javascript:` URLs** — not supported for security reasons
+
+---
+
+## Success Metrics
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| All 18 acceptance criteria pass | 100% | BDD test suite |
+| Navigation overhead | < 100ms above Chrome's own load time | Benchmark against raw CDP |
+| Error message clarity | Users understand what went wrong | Error messages include context and suggestions |
+
+---
+
+## Open Questions
+
+- [x] Should `navigate back` wait for page load? — Yes, default wait strategy applies
+- [x] How to get HTTP status code? — From `Page.navigate` response `errorText` (absence = success) and `Network.responseReceived` for status code
+- [x] Should `--wait-until` apply to back/forward/reload? — Not as a flag (they use default load wait), but the implementation should wait for the page to settle
+
+---
+
+## Validation Checklist
+
+- [x] User story follows "As a / I want / So that" format
+- [x] All acceptance criteria use Given/When/Then format
+- [x] No implementation details in requirements
+- [x] All criteria are testable and unambiguous
+- [x] Success metrics are measurable
+- [x] Edge cases and error states are specified
+- [x] Dependencies are identified
+- [x] Out of scope is defined
+- [x] Open questions are documented (or resolved)

--- a/.claude/specs/url-navigation/tasks.md
+++ b/.claude/specs/url-navigation/tasks.md
@@ -1,0 +1,221 @@
+# Tasks: URL Navigation
+
+**Issue**: #8
+**Date**: 2026-02-11
+**Status**: Planning
+**Author**: Claude (spec-driven development)
+
+---
+
+## Summary
+
+| Phase | Tasks | Status |
+|-------|-------|--------|
+| Setup | 2 | [ ] |
+| Backend | 4 | [ ] |
+| Integration | 1 | [ ] |
+| Testing | 2 | [ ] |
+| **Total** | **9** | |
+
+---
+
+## Phase 1: Setup
+
+### T001: Define CLI subcommand types for `navigate`
+
+**File(s)**: `src/cli/mod.rs`
+**Type**: Modify
+**Depends**: None
+**Acceptance**:
+- [ ] `Navigate` variant changes from unit variant to `Navigate(NavigateArgs)`
+- [ ] `NavigateArgs` struct uses `#[command(args_conflicts_with_subcommands = true)]`
+- [ ] `NavigateArgs` has optional `#[command(subcommand)] command: Option<NavigateCommand>`
+- [ ] `NavigateArgs` has `#[command(flatten)] url_args: NavigateUrlArgs` for the URL path
+- [ ] `NavigateUrlArgs` has positional `url: Option<String>`, `--wait-until` (WaitUntil enum, default load), `--timeout <MS>` (Option<u64>), `--ignore-cache` bool flag
+- [ ] `NavigateCommand` enum has `Back`, `Forward`, `Reload(NavigateReloadArgs)` variants
+- [ ] `NavigateReloadArgs` has `--ignore-cache` bool flag
+- [ ] `WaitUntil` enum has `Load`, `Domcontentloaded`, `Networkidle`, `None` variants with `#[derive(Clone, Copy, ValueEnum)]`
+- [ ] Note: `--tab` is already a global option on `GlobalOpts`, no need to add per-subcommand
+- [ ] `cargo check` passes with no errors
+- [ ] `chrome-cli navigate --help` shows URL arg and subcommands
+
+**Notes**: Use clap `args_conflicts_with_subcommands` so that `navigate <URL>` works without a subcommand keyword, while `navigate back/forward/reload` are subcommands. The global `--tab` and `--timeout` flags already exist; `--timeout` on `NavigateUrlArgs` is a navigate-specific override (for the wait strategy timeout, distinct from the global CDP command timeout). If the user provides `--timeout` on the navigate URL args, use it as the navigation wait timeout; otherwise default to 30000ms.
+
+### T002: Add error constructors for navigation failures
+
+**File(s)**: `src/error.rs`
+**Type**: Modify
+**Depends**: None
+**Acceptance**:
+- [ ] `AppError::navigation_failed(error_text: &str)` constructor added, returns `AppError { message: format!("Navigation failed: {error_text}"), code: ExitCode::GeneralError }`
+- [ ] `AppError::navigation_timeout(timeout_ms: u64, strategy: &str)` constructor added, returns `AppError { message: format!("Navigation timed out after {timeout_ms}ms waiting for {strategy}"), code: ExitCode::TimeoutError }`
+- [ ] Unit tests added for both constructors verifying message content and exit code
+- [ ] `cargo test --lib` passes
+
+---
+
+## Phase 2: Backend Implementation
+
+### T003: Implement `execute_url` handler (URL navigation with wait strategies)
+
+**File(s)**: `src/navigate.rs` (create new file)
+**Type**: Create
+**Depends**: T001, T002
+**Acceptance**:
+- [ ] Module has `pub async fn execute_navigate(global: &GlobalOpts, args: &NavigateArgs) -> Result<(), AppError>` that dispatches based on subcommand vs positional URL
+- [ ] If `args.command` is `Some(NavigateCommand::Back)` → call `execute_back()`
+- [ ] If `args.command` is `Some(NavigateCommand::Forward)` → call `execute_forward()`
+- [ ] If `args.command` is `Some(NavigateCommand::Reload(..))` → call `execute_reload()`
+- [ ] If `args.url_args.url` is `Some(url)` → call `execute_url()`
+- [ ] If neither subcommand nor URL → return error "No URL or subcommand provided"
+- [ ] `execute_url()` resolves connection via `resolve_connection()`
+- [ ] Resolves target tab via `resolve_target()` (uses global `--tab`)
+- [ ] Connects via `CdpClient::connect()` and `client.create_session(target_id)`
+- [ ] Wraps session in `ManagedSession::new()`
+- [ ] Enables Page domain via `managed.ensure_domain("Page")`
+- [ ] Enables Network domain via `managed.ensure_domain("Network")`
+- [ ] Subscribes to wait strategy events BEFORE sending `Page.navigate`
+- [ ] Subscribes to `Network.responseReceived` for HTTP status extraction
+- [ ] Sends `Page.navigate` with `{url}` params (and `transitionType: "typed"` if `--ignore-cache` is set, or uses separate cache-bypass approach)
+- [ ] Checks `Page.navigate` response for `errorText` field — if present, returns `AppError::navigation_failed(errorText)`
+- [ ] Waits for the selected strategy event(s) with timeout
+- [ ] Extracts HTTP status from `Network.responseReceived` where `type == "Document"` (first matching event)
+- [ ] Gets page title via `Runtime.evaluate("document.title")`
+- [ ] Gets final URL via `Runtime.evaluate("location.href")`
+- [ ] Outputs JSON: `{url, title, status}` via `print_output()`
+- [ ] `cargo check` passes
+
+**Notes**: The `--ignore-cache` flag for URL navigation can be implemented by enabling Network domain and calling `Network.setCacheDisabled(cacheDisabled: true)` before navigating, then restoring afterward. Alternatively, use the `Page.navigate` approach and note that `transitionType` doesn't disable cache — `Network.setCacheDisabled` is the correct CDP method.
+
+### T004: Implement wait strategy functions
+
+**File(s)**: `src/navigate.rs`
+**Type**: Modify
+**Depends**: T003
+**Acceptance**:
+- [ ] `wait_for_load(session, timeout)` subscribes to `Page.loadEventFired`, waits with `tokio::select!` between event and timeout
+- [ ] `wait_for_dom_content(session, timeout)` subscribes to `Page.domContentEventFired`, same pattern
+- [ ] `wait_for_network_idle(session, timeout)` subscribes to `Network.requestWillBeSent`, `Network.loadingFinished`, `Network.loadingFailed`
+- [ ] Network idle tracks `in_flight_count: u32`, increments on `requestWillBeSent`, decrements (saturating) on `loadingFinished`/`loadingFailed`
+- [ ] Network idle uses a 500ms idle timer: when `in_flight_count` reaches 0, starts 500ms countdown; if new request arrives, resets timer
+- [ ] Network idle has overall timeout from `--timeout`
+- [ ] `wait_none()` is a no-op (returns immediately)
+- [ ] All wait functions return `Result<(), AppError>` — `Ok(())` on success, `Err(navigation_timeout)` on timeout
+- [ ] `cargo check` passes
+
+**Notes**: The wait functions should accept the `CdpSession` (not `ManagedSession`) reference for subscribing, since `ManagedSession` delegates to the inner session. Actually, since `ManagedSession` doesn't expose `subscribe()`, the wait functions should be set up before wrapping in `ManagedSession`, or we should pass the session's subscribe capability. The simplest approach: subscribe via the session before wrapping in `ManagedSession`, or subscribe after domain enabling through the inner session. Consider adding a `subscribe()` method to `ManagedSession` that delegates to the inner session.
+
+**Updated approach**: Add a `subscribe(&self, method: &str)` method to `ManagedSession` in `src/connection.rs` that delegates to `self.session.subscribe(method)`. This keeps the pattern consistent and allows navigate.rs to only interact with `ManagedSession`.
+
+### T005: Implement `execute_back` and `execute_forward` handlers
+
+**File(s)**: `src/navigate.rs`
+**Type**: Modify
+**Depends**: T003
+**Acceptance**:
+- [ ] `execute_back()` resolves connection, target, creates session + ManagedSession
+- [ ] Enables Page domain
+- [ ] Sends `Page.getNavigationHistory` → extracts `currentIndex` and `entries`
+- [ ] If `currentIndex == 0` → returns current page info (not an error, just a no-op)
+- [ ] Otherwise, gets `entries[currentIndex - 1]` → `entryId`
+- [ ] Subscribes to `Page.loadEventFired`
+- [ ] Sends `Page.navigateToHistoryEntry` with `{entryId}`
+- [ ] Waits for `Page.loadEventFired` with timeout
+- [ ] Gets final URL and title (from history entry or `Runtime.evaluate`)
+- [ ] Outputs JSON: `{url, title}`
+- [ ] `execute_forward()` follows same pattern but navigates to `entries[currentIndex + 1]`
+- [ ] If `currentIndex == entries.len() - 1` → returns current page info (no-op)
+- [ ] `cargo check` passes
+
+### T006: Implement `execute_reload` handler
+
+**File(s)**: `src/navigate.rs`
+**Type**: Modify
+**Depends**: T003
+**Acceptance**:
+- [ ] `execute_reload()` resolves connection, target, creates session + ManagedSession
+- [ ] Enables Page domain
+- [ ] Subscribes to `Page.loadEventFired`
+- [ ] Sends `Page.reload` with `{ignoreCache: true}` if `--ignore-cache` flag is set, else `{}`
+- [ ] Waits for `Page.loadEventFired` with timeout
+- [ ] Gets current URL via `Runtime.evaluate("location.href")`
+- [ ] Gets current title via `Runtime.evaluate("document.title")`
+- [ ] Outputs JSON: `{url, title}`
+- [ ] `cargo check` passes
+
+---
+
+## Phase 3: Integration
+
+### T007: Wire navigate command dispatch in main.rs and expose subscribe on ManagedSession
+
+**File(s)**: `src/main.rs`, `src/connection.rs`
+**Type**: Modify
+**Depends**: T003, T004, T005, T006
+**Acceptance**:
+- [ ] `mod navigate;` declaration added to `main.rs`
+- [ ] `run()` match arm updated: `Command::Navigate(args) => navigate::execute_navigate(&cli.global, args).await`
+- [ ] `ManagedSession` in `src/connection.rs` gets a new `subscribe(&self, method: &str)` method that delegates to `self.session.subscribe(method)`
+- [ ] `cargo build` succeeds with no warnings
+- [ ] `cargo clippy` passes with project's lint settings (all=deny, pedantic=warn)
+- [ ] Running `chrome-cli navigate --help` shows URL positional arg and back/forward/reload subcommands
+- [ ] Running `chrome-cli navigate back --help` works
+- [ ] Running `chrome-cli navigate reload --help` shows --ignore-cache flag
+
+---
+
+## Phase 4: Testing
+
+### T008: Create BDD feature file for URL navigation
+
+**File(s)**: `tests/features/url-navigation.feature`
+**Type**: Create
+**Depends**: T007
+**Acceptance**:
+- [ ] Feature file covers all 18 acceptance criteria from requirements.md
+- [ ] Uses Background for common Chrome-running precondition
+- [ ] Scenarios are independent and self-contained
+- [ ] Valid Gherkin syntax
+- [ ] Scenario names match AC names from requirements
+
+### T009: Add unit tests for navigate command logic
+
+**File(s)**: `src/navigate.rs`, `src/error.rs`, `src/connection.rs`
+**Type**: Modify
+**Depends**: T003, T004, T005, T006, T007
+**Acceptance**:
+- [ ] Test: `WaitUntil` enum default is `Load`
+- [ ] Test: navigate error constructors (navigation_failed, navigation_timeout)
+- [ ] Test: history back at index 0 is a no-op
+- [ ] Test: history forward at last entry is a no-op
+- [ ] Test: `Page.navigate` errorText detection
+- [ ] Test: output struct serialization (NavigateResult, HistoryResult)
+- [ ] Test: ManagedSession.subscribe() returns a receiver (mock CDP test, similar to existing managed_session_enables_domain_once test)
+- [ ] All tests pass with `cargo test`
+
+---
+
+## Dependency Graph
+
+```
+T001 ──┬──▶ T003 ──┬──▶ T004
+       │           ├──▶ T005
+T002 ──┘           ├──▶ T006
+                   │
+                   └──┬──▶ T007 ──▶ T008
+                      │
+                      └──▶ T009
+```
+
+---
+
+## Validation Checklist
+
+- [x] Each task has single responsibility
+- [x] Dependencies are correctly mapped
+- [x] Tasks can be completed independently (given dependencies)
+- [x] Acceptance criteria are verifiable
+- [x] File paths reference actual project structure
+- [x] Test tasks are included
+- [x] No circular dependencies
+- [x] Tasks are in logical execution order

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -101,7 +101,7 @@ pub enum Command {
         long_about = "Navigate to URLs, reload pages, go back/forward in history, and wait for \
             navigation events. Supports waiting for load, DOMContentLoaded, or network idle."
     )]
-    Navigate,
+    Navigate(NavigateArgs),
 
     /// Page inspection (screenshot, text, accessibility tree, find)
     #[command(
@@ -240,6 +240,71 @@ pub struct TabsActivateArgs {
     /// Suppress output after activation
     #[arg(long)]
     pub quiet: bool,
+}
+
+/// Arguments for the `navigate` subcommand group.
+#[derive(Args)]
+#[command(args_conflicts_with_subcommands = true)]
+pub struct NavigateArgs {
+    #[command(subcommand)]
+    pub command: Option<NavigateCommand>,
+
+    #[command(flatten)]
+    pub url_args: NavigateUrlArgs,
+}
+
+/// Navigate subcommands.
+#[derive(Subcommand)]
+pub enum NavigateCommand {
+    /// Go back in browser history
+    Back,
+
+    /// Go forward in browser history
+    Forward,
+
+    /// Reload the current page
+    Reload(NavigateReloadArgs),
+}
+
+/// Arguments for direct URL navigation (`navigate <URL>`).
+#[derive(Args)]
+pub struct NavigateUrlArgs {
+    /// URL to navigate to
+    pub url: Option<String>,
+
+    /// Wait strategy after navigation
+    #[arg(long, value_enum, default_value_t = WaitUntil::Load)]
+    pub wait_until: WaitUntil,
+
+    /// Navigation timeout in milliseconds
+    #[arg(long)]
+    pub timeout: Option<u64>,
+
+    /// Bypass the browser cache
+    #[arg(long)]
+    pub ignore_cache: bool,
+}
+
+/// Arguments for `navigate reload`.
+#[derive(Args)]
+pub struct NavigateReloadArgs {
+    /// Bypass the browser cache on reload
+    #[arg(long)]
+    pub ignore_cache: bool,
+}
+
+/// Wait strategy for navigation commands.
+#[derive(Debug, Clone, Copy, ValueEnum, Default, PartialEq, Eq)]
+pub enum WaitUntil {
+    /// Wait for the load event
+    #[default]
+    Load,
+    /// Wait for DOMContentLoaded event
+    Domcontentloaded,
+    /// Wait until network is idle (no requests for 500ms)
+    Networkidle,
+    /// Return immediately after initiating navigation
+    None,
 }
 
 /// Arguments for the `connect` subcommand.

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 
-use crate::cdp::{CdpError, CdpSession};
+use crate::cdp::{CdpError, CdpEvent, CdpSession};
 use crate::chrome::{TargetInfo, discover_chrome, query_targets, query_version};
 use crate::error::AppError;
 use crate::session;
@@ -208,6 +208,18 @@ impl ManagedSession {
     #[must_use]
     pub fn session_id(&self) -> &str {
         self.session.session_id()
+    }
+
+    /// Subscribe to CDP events matching a method name within this session.
+    ///
+    /// # Errors
+    ///
+    /// Returns `CdpError` if the transport task has exited.
+    pub async fn subscribe(
+        &self,
+        method: &str,
+    ) -> Result<tokio::sync::mpsc::Receiver<CdpEvent>, CdpError> {
+        self.session.subscribe(method).await
     }
 
     /// Returns the set of currently enabled domains.

--- a/src/error.rs
+++ b/src/error.rs
@@ -96,6 +96,22 @@ impl AppError {
     }
 
     #[must_use]
+    pub fn navigation_failed(error_text: &str) -> Self {
+        Self {
+            message: format!("Navigation failed: {error_text}"),
+            code: ExitCode::GeneralError,
+        }
+    }
+
+    #[must_use]
+    pub fn navigation_timeout(timeout_ms: u64, strategy: &str) -> Self {
+        Self {
+            message: format!("Navigation timed out after {timeout_ms}ms waiting for {strategy}"),
+            code: ExitCode::TimeoutError,
+        }
+    }
+
+    #[must_use]
     pub fn no_chrome_found() -> Self {
         Self {
             message: "No Chrome instance found. Run 'chrome-cli connect' or \
@@ -195,6 +211,23 @@ mod tests {
         assert!(err.message.contains("Cannot close the last tab"));
         assert!(err.message.contains("at least one open tab"));
         assert!(matches!(err.code, ExitCode::TargetError));
+    }
+
+    #[test]
+    fn navigation_failed_error() {
+        let err = AppError::navigation_failed("net::ERR_NAME_NOT_RESOLVED");
+        assert!(err.message.contains("Navigation failed"));
+        assert!(err.message.contains("ERR_NAME_NOT_RESOLVED"));
+        assert!(matches!(err.code, ExitCode::GeneralError));
+    }
+
+    #[test]
+    fn navigation_timeout_error() {
+        let err = AppError::navigation_timeout(30000, "load");
+        assert!(err.message.contains("timed out"));
+        assert!(err.message.contains("30000ms"));
+        assert!(err.message.contains("load"));
+        assert!(matches!(err.code, ExitCode::TimeoutError));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod cli;
+mod navigate;
 mod tabs;
 
 use std::time::Duration;
@@ -31,7 +32,7 @@ async fn run(cli: &Cli) -> Result<(), AppError> {
     match &cli.command {
         Command::Connect(args) => execute_connect(&cli.global, args).await,
         Command::Tabs(args) => tabs::execute_tabs(&cli.global, args).await,
-        Command::Navigate => Err(AppError::not_implemented("navigate")),
+        Command::Navigate(args) => navigate::execute_navigate(&cli.global, args).await,
         Command::Page => Err(AppError::not_implemented("page")),
         Command::Dom => Err(AppError::not_implemented("dom")),
         Command::Js => Err(AppError::not_implemented("js")),

--- a/src/navigate.rs
+++ b/src/navigate.rs
@@ -1,0 +1,511 @@
+use std::time::Duration;
+
+use serde::Serialize;
+
+use chrome_cli::cdp::{CdpClient, CdpConfig, CdpEvent};
+use chrome_cli::connection::{ManagedSession, resolve_connection, resolve_target};
+use chrome_cli::error::{AppError, ExitCode};
+
+use crate::cli::{
+    GlobalOpts, NavigateArgs, NavigateCommand, NavigateReloadArgs, NavigateUrlArgs, WaitUntil,
+};
+
+/// Default navigation wait timeout in milliseconds.
+const DEFAULT_NAVIGATE_TIMEOUT_MS: u64 = 30_000;
+
+/// Network idle threshold in milliseconds.
+const NETWORK_IDLE_MS: u64 = 500;
+
+// =============================================================================
+// Output types
+// =============================================================================
+
+#[derive(Serialize)]
+struct NavigateResult {
+    url: String,
+    title: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    status: Option<u16>,
+}
+
+#[derive(Serialize)]
+struct HistoryResult {
+    url: String,
+    title: String,
+}
+
+// =============================================================================
+// Output formatting
+// =============================================================================
+
+fn print_output(value: &impl Serialize, output: &crate::cli::OutputFormat) -> Result<(), AppError> {
+    let json = if output.pretty {
+        serde_json::to_string_pretty(value)
+    } else {
+        serde_json::to_string(value)
+    };
+    let json = json.map_err(|e| AppError {
+        message: format!("serialization error: {e}"),
+        code: ExitCode::GeneralError,
+    })?;
+    println!("{json}");
+    Ok(())
+}
+
+// =============================================================================
+// Config helper
+// =============================================================================
+
+fn cdp_config(global: &GlobalOpts) -> CdpConfig {
+    let mut config = CdpConfig::default();
+    if let Some(timeout_ms) = global.timeout {
+        config.command_timeout = Duration::from_millis(timeout_ms);
+    }
+    config
+}
+
+// =============================================================================
+// Dispatcher
+// =============================================================================
+
+/// Execute the `navigate` subcommand group.
+///
+/// # Errors
+///
+/// Returns `AppError` if the subcommand fails.
+pub async fn execute_navigate(global: &GlobalOpts, args: &NavigateArgs) -> Result<(), AppError> {
+    match &args.command {
+        Some(NavigateCommand::Back) => execute_back(global).await,
+        Some(NavigateCommand::Forward) => execute_forward(global).await,
+        Some(NavigateCommand::Reload(reload_args)) => execute_reload(global, reload_args).await,
+        None => execute_url(global, &args.url_args).await,
+    }
+}
+
+// =============================================================================
+// Session setup
+// =============================================================================
+
+async fn setup_session(global: &GlobalOpts) -> Result<(CdpClient, ManagedSession), AppError> {
+    let conn = resolve_connection(&global.host, global.port, global.ws_url.as_deref()).await?;
+    let target = resolve_target(&conn.host, conn.port, global.tab.as_deref()).await?;
+
+    let config = cdp_config(global);
+    let client = CdpClient::connect(&conn.ws_url, config).await?;
+    let session = client.create_session(&target.id).await?;
+    let managed = ManagedSession::new(session);
+
+    Ok((client, managed))
+}
+
+// =============================================================================
+// URL navigation
+// =============================================================================
+
+async fn execute_url(global: &GlobalOpts, args: &NavigateUrlArgs) -> Result<(), AppError> {
+    let url = args.url.as_deref().ok_or_else(|| AppError {
+        message: "URL is required. Usage: chrome-cli navigate <URL>".into(),
+        code: ExitCode::GeneralError,
+    })?;
+
+    let timeout_ms = args.timeout.unwrap_or(DEFAULT_NAVIGATE_TIMEOUT_MS);
+    let (_client, mut managed) = setup_session(global).await?;
+
+    // Enable required domains
+    managed.ensure_domain("Page").await?;
+    managed.ensure_domain("Network").await?;
+
+    // Subscribe to events BEFORE navigating
+    let response_rx = managed.subscribe("Network.responseReceived").await?;
+
+    // Subscribe for wait strategy
+    let wait_rx = match args.wait_until {
+        WaitUntil::Load => Some(managed.subscribe("Page.loadEventFired").await?),
+        WaitUntil::Domcontentloaded => Some(managed.subscribe("Page.domContentEventFired").await?),
+        WaitUntil::Networkidle | WaitUntil::None => None,
+    };
+
+    // For network idle, we need request tracking subscriptions
+    let network_subs = if args.wait_until == WaitUntil::Networkidle {
+        let req_rx = managed.subscribe("Network.requestWillBeSent").await?;
+        let fin_rx = managed.subscribe("Network.loadingFinished").await?;
+        let fail_rx = managed.subscribe("Network.loadingFailed").await?;
+        Some((req_rx, fin_rx, fail_rx))
+    } else {
+        None
+    };
+
+    // Build navigate params
+    let params = serde_json::json!({ "url": url });
+    if args.ignore_cache {
+        // Page.navigate doesn't have ignoreCache; we use Network.setCacheDisabled instead
+        managed
+            .send_command(
+                "Network.setCacheDisabled",
+                Some(serde_json::json!({ "cacheDisabled": true })),
+            )
+            .await?;
+    }
+
+    // Navigate
+    let result = managed.send_command("Page.navigate", Some(params)).await?;
+
+    // Check for navigation errors (e.g., DNS failure)
+    if let Some(error_text) = result["errorText"].as_str() {
+        if !error_text.is_empty() {
+            return Err(AppError::navigation_failed(error_text));
+        }
+    }
+
+    let frame_id = result["frameId"].as_str().unwrap_or_default().to_string();
+
+    // Wait according to strategy
+    match args.wait_until {
+        WaitUntil::Load | WaitUntil::Domcontentloaded => {
+            if let Some(rx) = wait_rx {
+                wait_for_event(rx, timeout_ms, &format!("{:?}", args.wait_until)).await?;
+            }
+        }
+        WaitUntil::Networkidle => {
+            if let Some((req_rx, fin_rx, fail_rx)) = network_subs {
+                wait_for_network_idle(req_rx, fin_rx, fail_rx, timeout_ms).await?;
+            }
+        }
+        WaitUntil::None => {}
+    }
+
+    // Extract HTTP status from responseReceived events
+    let status = extract_http_status(response_rx, &frame_id);
+
+    // Get final page info
+    let (page_url, page_title) = get_page_info(&managed).await?;
+
+    let output = NavigateResult {
+        url: page_url,
+        title: page_title,
+        status,
+    };
+
+    print_output(&output, &global.output)
+}
+
+// =============================================================================
+// History: Back
+// =============================================================================
+
+async fn execute_back(global: &GlobalOpts) -> Result<(), AppError> {
+    let (_client, mut managed) = setup_session(global).await?;
+
+    managed.ensure_domain("Page").await?;
+
+    // Get navigation history
+    let history = managed
+        .send_command("Page.getNavigationHistory", None)
+        .await?;
+
+    #[allow(clippy::cast_possible_truncation)]
+    let current_index = history["currentIndex"].as_u64().unwrap_or(0) as usize;
+
+    if current_index == 0 {
+        return Err(AppError {
+            message: "Cannot go back: already at the beginning of history.".into(),
+            code: ExitCode::GeneralError,
+        });
+    }
+
+    let entries = history["entries"].as_array().ok_or_else(|| AppError {
+        message: "Invalid navigation history response".into(),
+        code: ExitCode::GeneralError,
+    })?;
+
+    let target_entry = &entries[current_index - 1];
+    let entry_id = target_entry["id"].as_i64().unwrap_or(0);
+
+    // Subscribe to load event before navigating
+    let load_rx = managed.subscribe("Page.loadEventFired").await?;
+
+    // Navigate to history entry
+    managed
+        .send_command(
+            "Page.navigateToHistoryEntry",
+            Some(serde_json::json!({ "entryId": entry_id })),
+        )
+        .await?;
+
+    // Wait for load
+    wait_for_event(load_rx, DEFAULT_NAVIGATE_TIMEOUT_MS, "load").await?;
+
+    let (page_url, page_title) = get_page_info(&managed).await?;
+
+    let output = HistoryResult {
+        url: page_url,
+        title: page_title,
+    };
+
+    print_output(&output, &global.output)
+}
+
+// =============================================================================
+// History: Forward
+// =============================================================================
+
+async fn execute_forward(global: &GlobalOpts) -> Result<(), AppError> {
+    let (_client, mut managed) = setup_session(global).await?;
+
+    managed.ensure_domain("Page").await?;
+
+    let history = managed
+        .send_command("Page.getNavigationHistory", None)
+        .await?;
+
+    #[allow(clippy::cast_possible_truncation)]
+    let current_index = history["currentIndex"].as_u64().unwrap_or(0) as usize;
+
+    let entries = history["entries"].as_array().ok_or_else(|| AppError {
+        message: "Invalid navigation history response".into(),
+        code: ExitCode::GeneralError,
+    })?;
+
+    let next_index = current_index + 1;
+    if next_index >= entries.len() {
+        return Err(AppError {
+            message: "Cannot go forward: already at the end of history.".into(),
+            code: ExitCode::GeneralError,
+        });
+    }
+
+    let target_entry = &entries[next_index];
+    let entry_id = target_entry["id"].as_i64().unwrap_or(0);
+
+    let load_rx = managed.subscribe("Page.loadEventFired").await?;
+
+    managed
+        .send_command(
+            "Page.navigateToHistoryEntry",
+            Some(serde_json::json!({ "entryId": entry_id })),
+        )
+        .await?;
+
+    wait_for_event(load_rx, DEFAULT_NAVIGATE_TIMEOUT_MS, "load").await?;
+
+    let (page_url, page_title) = get_page_info(&managed).await?;
+
+    let output = HistoryResult {
+        url: page_url,
+        title: page_title,
+    };
+
+    print_output(&output, &global.output)
+}
+
+// =============================================================================
+// Reload
+// =============================================================================
+
+async fn execute_reload(global: &GlobalOpts, args: &NavigateReloadArgs) -> Result<(), AppError> {
+    let (_client, mut managed) = setup_session(global).await?;
+
+    managed.ensure_domain("Page").await?;
+
+    let load_rx = managed.subscribe("Page.loadEventFired").await?;
+
+    let params = serde_json::json!({ "ignoreCache": args.ignore_cache });
+    managed.send_command("Page.reload", Some(params)).await?;
+
+    wait_for_event(load_rx, DEFAULT_NAVIGATE_TIMEOUT_MS, "load").await?;
+
+    let (page_url, page_title) = get_page_info(&managed).await?;
+
+    let output = HistoryResult {
+        url: page_url,
+        title: page_title,
+    };
+
+    print_output(&output, &global.output)
+}
+
+// =============================================================================
+// Wait strategies
+// =============================================================================
+
+async fn wait_for_event(
+    mut rx: tokio::sync::mpsc::Receiver<CdpEvent>,
+    timeout_ms: u64,
+    strategy: &str,
+) -> Result<(), AppError> {
+    let timeout = Duration::from_millis(timeout_ms);
+    tokio::select! {
+        event = rx.recv() => {
+            match event {
+                Some(_) => Ok(()),
+                None => Err(AppError {
+                    message: format!("Event channel closed while waiting for {strategy}"),
+                    code: ExitCode::GeneralError,
+                }),
+            }
+        }
+        () = tokio::time::sleep(timeout) => {
+            Err(AppError::navigation_timeout(timeout_ms, strategy))
+        }
+    }
+}
+
+async fn wait_for_network_idle(
+    mut req_rx: tokio::sync::mpsc::Receiver<CdpEvent>,
+    mut fin_rx: tokio::sync::mpsc::Receiver<CdpEvent>,
+    mut fail_rx: tokio::sync::mpsc::Receiver<CdpEvent>,
+    timeout_ms: u64,
+) -> Result<(), AppError> {
+    let timeout = Duration::from_millis(timeout_ms);
+    let idle_duration = Duration::from_millis(NETWORK_IDLE_MS);
+    let deadline = tokio::time::Instant::now() + timeout;
+
+    let mut in_flight: i64 = 0;
+    let idle_timer = tokio::time::sleep(idle_duration);
+    tokio::pin!(idle_timer);
+
+    loop {
+        tokio::select! {
+            event = req_rx.recv() => {
+                if event.is_some() {
+                    in_flight += 1;
+                    // Reset idle timer
+                    idle_timer.as_mut().reset(tokio::time::Instant::now() + idle_duration);
+                }
+            }
+            event = fin_rx.recv() => {
+                if event.is_some() {
+                    in_flight = (in_flight - 1).max(0);
+                    if in_flight == 0 {
+                        idle_timer.as_mut().reset(tokio::time::Instant::now() + idle_duration);
+                    }
+                }
+            }
+            event = fail_rx.recv() => {
+                if event.is_some() {
+                    in_flight = (in_flight - 1).max(0);
+                    if in_flight == 0 {
+                        idle_timer.as_mut().reset(tokio::time::Instant::now() + idle_duration);
+                    }
+                }
+            }
+            () = &mut idle_timer => {
+                if in_flight == 0 {
+                    return Ok(());
+                }
+                // Reset timer if still in-flight
+                idle_timer.as_mut().reset(tokio::time::Instant::now() + idle_duration);
+            }
+            () = tokio::time::sleep_until(deadline) => {
+                return Err(AppError::navigation_timeout(timeout_ms, "networkidle"));
+            }
+        }
+    }
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/// Get the current page URL and title via `Runtime.evaluate`.
+async fn get_page_info(managed: &ManagedSession) -> Result<(String, String), AppError> {
+    let url_result = managed
+        .send_command(
+            "Runtime.evaluate",
+            Some(serde_json::json!({ "expression": "location.href" })),
+        )
+        .await?;
+
+    let title_result = managed
+        .send_command(
+            "Runtime.evaluate",
+            Some(serde_json::json!({ "expression": "document.title" })),
+        )
+        .await?;
+
+    let url = url_result["result"]["value"]
+        .as_str()
+        .unwrap_or_default()
+        .to_string();
+    let title = title_result["result"]["value"]
+        .as_str()
+        .unwrap_or_default()
+        .to_string();
+
+    Ok((url, title))
+}
+
+/// Extract the HTTP status code from buffered `Network.responseReceived` events,
+/// matching the main frame.
+fn extract_http_status(
+    mut rx: tokio::sync::mpsc::Receiver<CdpEvent>,
+    frame_id: &str,
+) -> Option<u16> {
+    // Drain all buffered events
+    let mut status = None;
+    while let Ok(event) = rx.try_recv() {
+        // Match the response for the main frame document
+        let event_frame = event.params["frameId"].as_str().unwrap_or_default();
+        let resource_type = event.params["type"].as_str().unwrap_or_default();
+        if event_frame == frame_id && resource_type == "Document" {
+            if let Some(s) = event.params["response"]["status"].as_u64() {
+                #[allow(clippy::cast_possible_truncation)]
+                {
+                    status = Some(s as u16);
+                }
+            }
+        }
+    }
+    status
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn navigate_result_serialization() {
+        let result = NavigateResult {
+            url: "https://example.com".to_string(),
+            title: "Example".to_string(),
+            status: Some(200),
+        };
+        let json: serde_json::Value = serde_json::to_value(&result).unwrap();
+        assert_eq!(json["url"], "https://example.com");
+        assert_eq!(json["title"], "Example");
+        assert_eq!(json["status"], 200);
+    }
+
+    #[test]
+    fn navigate_result_without_status() {
+        let result = NavigateResult {
+            url: "https://example.com".to_string(),
+            title: "Example".to_string(),
+            status: None,
+        };
+        let json: serde_json::Value = serde_json::to_value(&result).unwrap();
+        assert_eq!(json["url"], "https://example.com");
+        assert!(json.get("status").is_none());
+    }
+
+    #[test]
+    fn history_result_serialization() {
+        let result = HistoryResult {
+            url: "https://example.com".to_string(),
+            title: "Example".to_string(),
+        };
+        let json: serde_json::Value = serde_json::to_value(&result).unwrap();
+        assert_eq!(json["url"], "https://example.com");
+        assert_eq!(json["title"], "Example");
+    }
+
+    #[test]
+    fn wait_until_default_is_load() {
+        let default = WaitUntil::default();
+        assert_eq!(default, WaitUntil::Load);
+    }
+}

--- a/tests/features/cli-skeleton.feature
+++ b/tests/features/cli-skeleton.feature
@@ -37,7 +37,7 @@ Feature: CLI skeleton with clap derive macros and top-level help
   Scenario: Default connection values are applied
     Given chrome-cli is built
     When I run "chrome-cli navigate"
-    Then stderr should contain "not yet implemented"
+    Then stderr should contain "URL is required"
     And the exit code should be 1
 
   # --- Output Format Conflicts ---
@@ -59,7 +59,6 @@ Feature: CLI skeleton with clap derive macros and top-level help
 
     Examples:
       | subcommand |
-      | navigate   |
       | page       |
       | dom        |
       | js         |
@@ -82,7 +81,7 @@ Feature: CLI skeleton with clap derive macros and top-level help
 
   Scenario: Error output is structured JSON on stderr
     Given chrome-cli is built
-    When I run "chrome-cli navigate"
+    When I run "chrome-cli page"
     Then the exit code should be 1
     And stderr should be valid JSON
     And stderr JSON should have key "error"
@@ -94,19 +93,19 @@ Feature: CLI skeleton with clap derive macros and top-level help
     Given chrome-cli is built
     When I run "chrome-cli --port 9333 --host 192.168.1.100 navigate"
     Then the exit code should be 1
-    And stderr should contain "not yet implemented"
+    And stderr should contain "URL is required"
 
   Scenario: WebSocket URL option is accepted
     Given chrome-cli is built
     When I run "chrome-cli --ws-url ws://localhost:9222/devtools/browser/abc navigate"
     Then the exit code should be 1
-    And stderr should contain "not yet implemented"
+    And stderr should contain "URL is required"
 
   Scenario: Timeout option is accepted
     Given chrome-cli is built
     When I run "chrome-cli --timeout 5000 navigate"
     Then the exit code should be 1
-    And stderr should contain "not yet implemented"
+    And stderr should contain "URL is required"
 
   Scenario: Tab ID option is accepted
     Given chrome-cli is built

--- a/tests/features/url-navigation.feature
+++ b/tests/features/url-navigation.feature
@@ -1,0 +1,160 @@
+# File: tests/features/url-navigation.feature
+#
+# Generated from: .claude/specs/url-navigation/requirements.md
+# Issue: #8
+
+Feature: URL Navigation
+  As a developer or automation engineer
+  I want to navigate Chrome to URLs and traverse browser history from the CLI
+  So that I can script browser navigation workflows without manual interaction
+
+  Background:
+    Given Chrome is running with CDP enabled
+
+  # --- URL Navigation: Happy Path ---
+
+  Scenario: AC1 - Navigate to a valid URL
+    Given a tab is open with "about:blank"
+    When I run "chrome-cli navigate https://example.com"
+    Then the exit code is 0
+    And the JSON output has key "url" containing "example.com"
+    And the JSON output has key "title" with a non-empty string
+    And the JSON output has key "status" with a numeric value
+
+  Scenario: AC2 - Navigate with --tab to target a specific tab
+    Given two tabs are open
+    And the second tab has ID "<TAB_ID>"
+    When I run "chrome-cli navigate https://example.com --tab <TAB_ID>"
+    Then the exit code is 0
+    And the JSON output has key "url" containing "example.com"
+    And the first tab URL is unchanged
+
+  # --- Wait Strategies ---
+
+  Scenario: AC3 - Navigate with --wait-until load (default)
+    Given a tab is open
+    When I run "chrome-cli navigate https://example.com --wait-until load"
+    Then the exit code is 0
+    And the command waited for the page load event
+    And the JSON output has key "url"
+    And the JSON output has key "title"
+    And the JSON output has key "status"
+
+  Scenario: AC4 - Navigate with --wait-until domcontentloaded
+    Given a tab is open
+    When I run "chrome-cli navigate https://example.com --wait-until domcontentloaded"
+    Then the exit code is 0
+    And the command returned after DOMContentLoaded fired
+    And the JSON output has key "url"
+    And the JSON output has key "title"
+    And the JSON output has key "status"
+
+  Scenario: AC5 - Navigate with --wait-until networkidle
+    Given a tab is open
+    When I run "chrome-cli navigate https://example.com --wait-until networkidle"
+    Then the exit code is 0
+    And the command waited until network was idle for 500ms
+    And the JSON output has key "url"
+    And the JSON output has key "title"
+    And the JSON output has key "status"
+
+  Scenario: AC6 - Navigate with --wait-until none
+    Given a tab is open
+    When I run "chrome-cli navigate https://example.com --wait-until none"
+    Then the exit code is 0
+    And the command returned immediately after initiating navigation
+    And the JSON output has key "url"
+
+  # --- Timeout ---
+
+  Scenario: AC7 - Navigate with --timeout
+    Given a tab is open
+    When I run "chrome-cli navigate https://httpbin.org/delay/60 --timeout 1000"
+    Then the exit code is 4
+    And the error message contains "timed out"
+    And the error message contains "1000ms"
+
+  # --- Cache Bypass ---
+
+  Scenario: AC8 - Navigate with --ignore-cache
+    Given a tab is open
+    When I run "chrome-cli navigate https://example.com --ignore-cache"
+    Then the exit code is 0
+    And the navigation bypassed the browser cache
+    And the JSON output has key "url"
+
+  # --- History: Back ---
+
+  Scenario: AC9 - Navigate back in browser history
+    Given a tab is open with "https://example.com"
+    And the tab has navigated to "https://www.iana.org/domains/reserved"
+    When I run "chrome-cli navigate back"
+    Then the exit code is 0
+    And the JSON output has key "url" containing "example.com"
+    And the JSON output has key "title"
+
+  Scenario: AC10 - Navigate back with --tab
+    Given two tabs are open
+    And the second tab has navigated to two pages
+    When I run "chrome-cli navigate back --tab <TAB_ID>"
+    Then the exit code is 0
+    And the JSON output has key "url"
+    And the specified tab navigated back
+
+  # --- History: Forward ---
+
+  Scenario: AC11 - Navigate forward in browser history
+    Given a tab has navigated to two pages and then gone back
+    When I run "chrome-cli navigate forward"
+    Then the exit code is 0
+    And the JSON output has key "url" containing the second page URL
+    And the JSON output has key "title"
+
+  Scenario: AC12 - Navigate forward with --tab
+    Given two tabs are open
+    And the second tab has gone back and has forward history
+    When I run "chrome-cli navigate forward --tab <TAB_ID>"
+    Then the exit code is 0
+    And the specified tab navigated forward
+
+  # --- Reload ---
+
+  Scenario: AC13 - Reload the current page
+    Given a tab is open with "https://example.com"
+    When I run "chrome-cli navigate reload"
+    Then the exit code is 0
+    And the JSON output has key "url" containing "example.com"
+    And the JSON output has key "title"
+
+  Scenario: AC14 - Reload with --ignore-cache
+    Given a tab is open with "https://example.com"
+    When I run "chrome-cli navigate reload --ignore-cache"
+    Then the exit code is 0
+    And the page was reloaded bypassing the cache
+
+  Scenario: AC15 - Reload with --tab
+    Given two tabs are open with pages loaded
+    When I run "chrome-cli navigate reload --tab <TAB_ID>"
+    Then the exit code is 0
+    And the specified tab was reloaded
+
+  # --- Error Handling ---
+
+  Scenario: AC16 - DNS resolution failure
+    Given a tab is open
+    When I run "chrome-cli navigate https://this-domain-does-not-exist.invalid"
+    Then the exit code is not 0
+    And the error message contains "Navigation failed"
+    And the error message contains "ERR_NAME_NOT_RESOLVED" or a DNS-related message
+
+  Scenario: AC17 - Navigation timeout
+    Given a tab is open
+    When I run "chrome-cli navigate https://httpbin.org/delay/60 --timeout 1000"
+    Then the exit code is 4
+    And the error message contains "timed out"
+
+  Scenario: AC18 - No Chrome connection
+    Given no Chrome instance is running
+    When I run "chrome-cli navigate https://example.com"
+    Then the exit code is 2
+    And the error message contains "No Chrome instance found" or "chrome-cli connect"


### PR DESCRIPTION
## Summary

- Adds the `navigate` subcommand group: URL navigation, `back`, `forward`, and `reload`
- First feature using session-level CDP communication (`CdpSession` + `ManagedSession`)
- Implements configurable wait strategies: `load` (default), `domcontentloaded`, `networkidle` (500ms idle window), and `none`
- Extracts HTTP status from `Network.responseReceived` events for the main frame document

## Changes

| File | Change |
|------|--------|
| `src/navigate.rs` | **New** — all navigate command handlers, wait strategies, helpers, and unit tests |
| `src/cli/mod.rs` | `Navigate` variant now wraps `NavigateArgs`; added `NavigateCommand`, `NavigateUrlArgs`, `NavigateReloadArgs`, `WaitUntil` |
| `src/connection.rs` | Added `ManagedSession::subscribe()` delegating to `CdpSession` |
| `src/error.rs` | Added `navigation_failed()` and `navigation_timeout()` constructors with tests |
| `src/main.rs` | Added `mod navigate;` and updated dispatch |
| `tests/features/url-navigation.feature` | BDD scenarios for all acceptance criteria |
| `.claude/specs/url-navigation/` | Design doc, requirements, feature spec, task breakdown |

## Test plan

- [x] `cargo check` — no compilation errors
- [x] `cargo clippy -- -D warnings -W clippy::pedantic` — clean
- [x] `cargo test --lib` — 81 tests pass
- [x] `cargo test --bin chrome-cli` — 12 tests pass (4 new navigate tests)
- [x] `chrome-cli navigate --help` shows URL arg, subcommands, and flags
- [x] `chrome-cli navigate back --help` shows `--tab` global option
- [x] `chrome-cli navigate reload --help` shows `--ignore-cache` flag
- [ ] Manual test with running Chrome: `chrome-cli navigate https://example.com`

Closes #8