### PR TITLE
feat: JavaScript execution in page context (#13)

### DIFF
--- a/.claude/specs/js-execution/design.md
+++ b/.claude/specs/js-execution/design.md
@@ -1,0 +1,308 @@
+# Design: JavaScript Execution in Page Context
+
+**Issue**: #13
+**Date**: 2026-02-12
+**Status**: Draft
+**Author**: Claude (writing-specs)
+
+---
+
+## Overview
+
+This feature adds the `js exec` subcommand to execute arbitrary JavaScript in the browser page context. It exposes two CDP methods — `Runtime.evaluate` for expressions and `Runtime.callFunctionOn` for function calls with element context — through a unified CLI interface. The implementation follows the same layered patterns as existing commands (`page`, `perf`, `tabs`): parse CLI args, resolve connection, create a managed CDP session, execute CDP commands, and format output as JSON.
+
+The key design decisions are: (1) using `Runtime.evaluate` with `awaitPromise: true` by default, (2) using `Runtime.callFunctionOn` with `DOM.resolveNode` for the `--uid` element context feature, (3) supporting code input from positional argument, `--file`, or stdin, and (4) capturing console messages via `Runtime.consoleAPICalled` events.
+
+---
+
+## Architecture
+
+### Component Diagram
+
+```
+CLI Layer (cli/mod.rs)
+  └── JsArgs → JsCommand::Exec(JsExecArgs)
+        ↓
+Command Layer (js.rs)       ← NEW FILE
+  └── execute_js() → execute_exec()
+        ↓
+Connection Layer (connection.rs)  ← existing
+  └── resolve_connection() → resolve_target() → ManagedSession
+        ↓
+CDP Layer (cdp/client.rs)     ← existing
+  ├── Runtime.evaluate({ expression, awaitPromise, returnByValue })
+  ├── Runtime.callFunctionOn({ functionDeclaration, objectId })
+  ├── Runtime.consoleAPICalled (event subscription)
+  └── DOM.resolveNode({ backendNodeId })
+        ↓
+Chrome Browser
+  └── Executes JS, returns result
+```
+
+### Data Flow
+
+```
+1. User runs: chrome-cli js exec <CODE> [--file PATH] [--uid UID] [--no-await] [--timeout MS] [--max-size N]
+2. CLI layer parses args into JsExecArgs
+3. Resolve code source:
+   a. If --file: read file contents
+   b. If code is "-": read stdin
+   c. Otherwise: use positional argument directly
+4. Command layer resolves connection and target tab (standard setup_session)
+5. Creates CdpSession via Target.attachToTarget
+6. Enables Runtime domain (via ManagedSession.ensure_domain)
+7. Subscribe to Runtime.consoleAPICalled for console capture
+8. Branch on --uid:
+   a. Without --uid: Runtime.evaluate with expression
+   b. With --uid:
+      i.   Read snapshot state → resolve UID to backendNodeId
+      ii.  Enable DOM domain
+      iii. DOM.resolveNode({ backendNodeId }) → get remote objectId
+      iv.  Runtime.callFunctionOn({ functionDeclaration, objectId, arguments: [objectId] })
+9. Handle result:
+   - Success → JsExecResult { result, type, console, truncated }
+   - Exception → structured error with error message + stack trace
+   - Timeout → timeout error
+10. Apply --max-size truncation if result exceeds limit
+11. Format output via print_output (JSON / pretty JSON)
+```
+
+---
+
+## API / Interface Changes
+
+### New CLI Commands
+
+| Command | Purpose |
+|---------|---------|
+| `chrome-cli js exec <CODE>` | Execute JavaScript in the page context |
+
+### CLI Arguments (JsExecArgs)
+
+| Argument | Type | Required | Default | Description |
+|----------|------|----------|---------|-------------|
+| `<code>` | `Option<String>` (positional) | Conditional | None | JavaScript code to execute; `-` reads stdin |
+| `--file <PATH>` | `Option<PathBuf>` | No | None | Read JavaScript from a file |
+| `--uid <UID>` | `Option<String>` | No | None | Element UID from snapshot; function receives element as first arg |
+| `--no-await` | `bool` (flag) | No | `false` | Do not await promise results |
+| `--timeout <MS>` | `Option<u64>` | No | Global timeout | Execution-specific timeout override |
+| `--max-size <BYTES>` | `Option<usize>` | No | None (unlimited) | Truncate results exceeding this size |
+
+Global flags `--tab`, `--json`, `--pretty`, `--plain`, `--host`, `--port`, `--ws-url` all apply as usual.
+
+**Mutual exclusion**: `<code>` and `--file` are mutually exclusive. One of `<code>` or `--file` is required.
+
+### Output Schema
+
+**JSON mode** (success):
+
+```json
+{
+  "result": "Example Domain",
+  "type": "string"
+}
+```
+
+With console output:
+
+```json
+{
+  "result": 42,
+  "type": "number",
+  "console": [
+    { "level": "log", "text": "hello" }
+  ]
+}
+```
+
+With truncation:
+
+```json
+{
+  "result": "xxxxxxxxxx...",
+  "type": "string",
+  "truncated": true
+}
+```
+
+**Error output** (stderr):
+
+```json
+{
+  "error": "ReferenceError: foo is not defined",
+  "stack": "ReferenceError: foo is not defined\n    at <anonymous>:1:1",
+  "code": 1
+}
+```
+
+### Errors
+
+| Condition | Error Message | Exit Code |
+|-----------|---------------|-----------|
+| JS exception | `"JavaScript execution failed: {description}"` | `GeneralError` (1) |
+| File not found | `"Script file not found: {path}"` | `GeneralError` (1) |
+| File read error | `"Failed to read script file: {path}: {error}"` | `GeneralError` (1) |
+| UID not found | Existing `uid_not_found` | `GeneralError` (1) |
+| No snapshot | `"No snapshot state found. Run 'chrome-cli page snapshot' first."` | `GeneralError` (1) |
+| No code provided | `"No JavaScript code provided. Specify code as argument, --file, or pipe via stdin."` | `GeneralError` (1) |
+| No connection | Existing `no_session` / `no_chrome_found` | `ConnectionError` (2) |
+| Tab not found | Existing `target_not_found` | `TargetError` (3) |
+| Timeout | Existing `command_timeout` from CDP layer | `TimeoutError` (4) |
+
+---
+
+## New Files and Modifications
+
+### New Files
+
+| File | Purpose |
+|------|---------|
+| `src/js.rs` | JavaScript execution command implementation (dispatcher, exec logic, output types, helpers) |
+
+### Modified Files
+
+| File | Change |
+|------|--------|
+| `src/cli/mod.rs` | Add `JsArgs`, `JsCommand`, `JsExecArgs` structs; change `Js` variant to `Js(JsArgs)` |
+| `src/main.rs` | Add `mod js;` import; wire `Command::Js(args)` to `js::execute_js()` |
+| `src/error.rs` | Add `js_execution_failed()`, `script_file_not_found()`, `script_file_read_failed()`, `no_js_code()` helper constructors |
+
+### No Changes Needed
+
+| Component | Why |
+|-----------|-----|
+| `src/cdp/*` | `Runtime.evaluate` and event subscription already work; `Runtime.callFunctionOn` uses the same `send_command` pattern |
+| `src/connection.rs` | `resolve_connection`, `resolve_target`, `ManagedSession` all reusable as-is |
+| `src/snapshot.rs` | `read_snapshot_state()` already exists for UID resolution |
+| `src/lib.rs` | No new public modules (js.rs is a binary-only module like page.rs) |
+
+---
+
+## JavaScript Execution Strategies
+
+### Strategy 1: Expression evaluation (no --uid)
+
+Uses `Runtime.evaluate`:
+
+```json
+{
+  "expression": "<user code>",
+  "returnByValue": true,
+  "awaitPromise": true,
+  "generatePreview": true
+}
+```
+
+- `returnByValue: true` ensures we get the serialized value, not a remote object reference
+- `awaitPromise: true` (default) waits for promises; disabled by `--no-await`
+- `generatePreview: true` provides useful string representations for complex objects
+
+### Strategy 2: Element context execution (--uid)
+
+Uses `DOM.resolveNode` + `Runtime.callFunctionOn`:
+
+```
+Step 1: Read snapshot state → get backendNodeId for UID
+Step 2: DOM.resolveNode({ backendNodeId }) → get objectId (remote object reference)
+Step 3: Runtime.callFunctionOn({
+  functionDeclaration: "<user code>",
+  objectId: <resolved objectId>,
+  arguments: [{ objectId: <resolved objectId> }],
+  returnByValue: true,
+  awaitPromise: true
+})
+```
+
+The user provides a function like `(el) => el.textContent`. The resolved DOM element is passed as the first argument. `callFunctionOn` is the correct CDP method for this because it provides the object context.
+
+### Console Capture
+
+Before executing user code, subscribe to `Runtime.consoleAPICalled` events:
+
+```
+1. managed.subscribe("Runtime.consoleAPICalled")
+2. Execute user code
+3. Collect any console events received during execution
+4. Include in output as "console" array
+```
+
+Each console entry: `{ "level": "log|warn|error|info", "text": "<message>" }`.
+
+### Result Truncation (--max-size)
+
+After receiving the result, check its serialized JSON size against `--max-size`:
+
+```
+1. Serialize result to JSON string
+2. If byte length > max_size:
+   a. Truncate the serialized string to max_size bytes
+   b. Set truncated = true in output
+3. Otherwise: use full result, omit truncated field
+```
+
+---
+
+## Alternatives Considered
+
+| Option | Description | Pros | Cons | Decision |
+|--------|-------------|------|------|----------|
+| **A: `Runtime.evaluate` only** | Use `evaluate` for all cases, wrap element into expression | Simple, single code path | Cannot pass live DOM element references; would need to re-query by selector | Rejected — cannot reliably pass element context |
+| **B: `Runtime.evaluate` + `callFunctionOn`** | Use `evaluate` for expressions, `callFunctionOn` for `--uid` | Clean separation, correct semantics for element context | Two code paths | **Selected** — matches CDP design intent |
+| **C: Wrap user code in IIFE** | Always wrap in `(function() { return <code>; })()` | Uniform execution | Breaks expressions like `document.title`, changes semantics | Rejected — too opinionated |
+
+---
+
+## Security Considerations
+
+- [x] **No sandboxing needed**: This is a power-user tool; the user controls the browser and the code they execute. The issue explicitly states "no sandboxing needed."
+- [x] **Local CDP only**: CDP connections are localhost-only by default (per `tech.md`), so remote code execution is not a concern.
+- [x] **File access**: `--file` reads local files, which is standard CLI behavior. No path traversal concern since the user controls the argument.
+- [x] **stdin**: Reading from stdin is standard Unix pipeline behavior.
+
+---
+
+## Performance Considerations
+
+- [x] **Single CDP round-trip** for expressions (Runtime.evaluate)
+- [x] **Two CDP round-trips** for element context (DOM.resolveNode + Runtime.callFunctionOn)
+- [x] **`returnByValue: true`** avoids an extra round-trip to fetch remote objects
+- [x] **Console subscription** is lightweight — events arrive asynchronously during execution
+- [x] **Truncation** happens client-side after receiving the full result (no way to limit at CDP level)
+
+---
+
+## Testing Strategy
+
+| Layer | Type | Coverage |
+|-------|------|----------|
+| Output types | Unit | Serialization of `JsExecResult`, `JsExecError` (JSON fields, skip_serializing_if) |
+| Error helpers | Unit | New error constructors produce correct messages and exit codes |
+| Code resolution | Unit | Positional arg, --file, stdin, mutual exclusion |
+| Result type mapping | Unit | All 7 JS types → correct `type` string |
+| Truncation logic | Unit | Result exceeds --max-size, truncated flag set |
+| Feature | BDD (Gherkin) | All 16 acceptance criteria as scenarios |
+
+---
+
+## Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Large JS results cause memory pressure | Low | Med | `--max-size` truncation; `returnByValue: true` streams result directly |
+| `DOM.resolveNode` fails for stale snapshots | Med | Low | Clear error message: "Run `page snapshot` first" |
+| Console capture races (messages arrive after result) | Low | Low | Small delay or drain after receiving result; console messages are best-effort |
+| Stdin blocks indefinitely if no data piped | Low | Med | Document that `-` reads until EOF; bounded by global `--timeout` |
+
+---
+
+## Validation Checklist
+
+- [x] Architecture follows existing project patterns (per `structure.md`)
+- [x] All API/interface changes documented with schemas
+- [x] No database/storage changes needed
+- [x] No state management changes needed
+- [x] Security considerations addressed
+- [x] Performance impact analyzed
+- [x] Testing strategy defined
+- [x] Alternatives were considered and documented
+- [x] Risks identified with mitigations

--- a/.claude/specs/js-execution/feature.gherkin
+++ b/.claude/specs/js-execution/feature.gherkin
@@ -1,0 +1,141 @@
+# File: tests/features/js-execution.feature
+#
+# Generated from: .claude/specs/js-execution/requirements.md
+# Issue: #13
+
+Feature: JavaScript execution in page context
+  As a developer / automation engineer
+  I want to execute arbitrary JavaScript in the browser page context via the CLI
+  So that I can perform custom automation and data extraction from scripts
+
+  Background:
+    Given Chrome is running with CDP enabled
+
+  # --- Happy Path ---
+
+  Scenario: Execute a JavaScript expression
+    Given a page is loaded at "https://example.com"
+    When I run "chrome-cli js exec 'document.title'"
+    Then stdout contains JSON with keys "result", "type"
+    And the "result" field is "Example Domain"
+    And the "type" field is "string"
+
+  Scenario: Execute a JavaScript function
+    Given a page is loaded at "https://example.com"
+    When I run "chrome-cli js exec '() => { return 2 + 2; }'"
+    Then the "result" field is 4
+    And the "type" field is "number"
+
+  Scenario Outline: Return all JavaScript value types
+    Given a page is loaded at "https://example.com"
+    When I run "chrome-cli js exec '<expression>'"
+    Then the "type" field is "<expected_type>"
+
+    Examples:
+      | expression            | expected_type |
+      | 'hello'               | string        |
+      | 42                    | number        |
+      | true                  | boolean       |
+      | null                  | object        |
+      | undefined             | undefined     |
+      | ({key: 'val'})        | object        |
+      | [1, 2, 3]             | object        |
+
+  # --- Tab Targeting ---
+
+  Scenario: Target a specific tab with --tab
+    Given multiple tabs are open
+    And the second tab is loaded at "https://example.org"
+    When I run "chrome-cli js exec --tab <SECOND_TAB_ID> 'document.title'"
+    Then the "result" field reflects the second tab's title
+
+  # --- Promise Handling ---
+
+  Scenario: Await promise results by default
+    Given a page is loaded at "https://example.com"
+    When I run "chrome-cli js exec 'new Promise(r => setTimeout(() => r(\"done\"), 100))'"
+    Then the "result" field is "done"
+    And the "type" field is "string"
+
+  Scenario: Disable promise awaiting with --no-await
+    Given a page is loaded at "https://example.com"
+    When I run "chrome-cli js exec --no-await 'new Promise(r => r(42))'"
+    Then the "type" field is "object"
+
+  # --- Timeout ---
+
+  Scenario: Execution timeout with --timeout
+    Given a page is loaded at "https://example.com"
+    When I run "chrome-cli js exec --timeout 100 'new Promise(() => {})'"
+    Then stderr contains a JSON error indicating timeout
+    And the exit code is non-zero
+
+  # --- File and Stdin Input ---
+
+  Scenario: Execute JavaScript from a file
+    Given a page is loaded at "https://example.com"
+    And a temporary file contains "document.title"
+    When I run "chrome-cli js exec --file <TEMP_FILE>"
+    Then the "result" field is "Example Domain"
+    And the "type" field is "string"
+
+  Scenario: Read code from stdin with dash argument
+    Given a page is loaded at "https://example.com"
+    When I pipe "document.title" to "chrome-cli js exec -"
+    Then the "result" field is "Example Domain"
+    And the "type" field is "string"
+
+  # --- Element Context ---
+
+  Scenario: Element context execution with --uid
+    Given a page is loaded at "https://example.com"
+    And a snapshot has been taken with "chrome-cli page snapshot"
+    And element "s1" exists in the snapshot
+    When I run "chrome-cli js exec --uid s1 '(el) => el.textContent'"
+    Then the "result" field contains the element's text content
+    And the "type" field is "string"
+
+  # --- Error Handling ---
+
+  Scenario: JavaScript exception returned as structured error
+    Given a page is loaded at "https://example.com"
+    When I run "chrome-cli js exec 'throw new Error(\"test error\")'"
+    Then stderr contains a JSON error with key "error"
+    And the error message contains "Error: test error"
+    And the exit code is non-zero
+
+  Scenario: Reference error for undefined variable
+    Given a page is loaded at "https://example.com"
+    When I run "chrome-cli js exec 'nonExistentVariable'"
+    Then stderr contains a JSON error
+    And the error message contains "ReferenceError"
+    And the exit code is non-zero
+
+  Scenario: UID not found error
+    Given a page is loaded at "https://example.com"
+    When I run "chrome-cli js exec --uid s999 '(el) => el.textContent'"
+    Then stderr contains a JSON error about UID not found
+    And the exit code is non-zero
+
+  Scenario: File not found error
+    Given a page is loaded at "https://example.com"
+    When I run "chrome-cli js exec --file /nonexistent/script.js"
+    Then stderr contains a JSON error about file not found
+    And the exit code is non-zero
+
+  # --- Truncation ---
+
+  Scenario: Large result truncation with --max-size
+    Given a page is loaded at "https://example.com"
+    When I run "chrome-cli js exec --max-size 100 \"'x'.repeat(10000)\""
+    Then the JSON output contains a "truncated" field set to true
+    And the "result" field is shorter than 10000 characters
+
+  # --- Console Capture ---
+
+  Scenario: Console output captured during execution
+    Given a page is loaded at "https://example.com"
+    When I run "chrome-cli js exec 'console.log(\"hello\"); 42'"
+    Then the "result" field is 42
+    And the "console" field is an array
+    And the "console" array contains an entry with level "log" and text "hello"

--- a/.claude/specs/js-execution/requirements.md
+++ b/.claude/specs/js-execution/requirements.md
@@ -1,0 +1,381 @@
+# Requirements: JavaScript Execution in Page Context
+
+**Issue**: #13
+**Date**: 2026-02-12
+**Status**: Draft
+**Author**: Claude (writing-specs)
+
+---
+
+## User Story
+
+**As a** developer / automation engineer
+**I want** to execute arbitrary JavaScript in the browser page context via the CLI
+**So that** I can perform custom automation, data extraction, and DOM manipulation from scripts and pipelines
+
+---
+
+## Background
+
+JavaScript execution is a fundamental building block for browser automation. While dedicated commands like `page text` and `element find` cover common patterns, many automation tasks require running arbitrary JavaScript — evaluating expressions, calling functions, extracting computed values, or triggering UI interactions. The `js exec` command exposes `Runtime.evaluate` and `Runtime.callFunctionOn` from the Chrome DevTools Protocol, giving power users direct access to the page's JavaScript execution context. This is an MVP feature identified in the product steering document.
+
+---
+
+## Acceptance Criteria
+
+**IMPORTANT: Each criterion becomes a Gherkin BDD test scenario.**
+
+### AC1: Execute a JavaScript expression
+
+**Given** Chrome is running with a page loaded at "https://example.com"
+**When** I run `chrome-cli js exec "document.title"`
+**Then** stdout contains JSON with `result` and `type` fields
+**And** the `result` field contains the page title string
+**And** the `type` field is `"string"`
+
+**Example**:
+- Given: Page loaded at https://example.com
+- When: `chrome-cli js exec "document.title"`
+- Then: `{"result":"Example Domain","type":"string"}`
+
+### AC2: Execute a JavaScript function
+
+**Given** Chrome is running with a page loaded
+**When** I run `chrome-cli js exec "() => { return 2 + 2; }"`
+**Then** the `result` field is `4`
+**And** the `type` field is `"number"`
+
+### AC3: Return all JavaScript value types
+
+**Given** Chrome is running with a page loaded
+**When** I execute JavaScript that returns a string, number, boolean, null, undefined, object, or array
+**Then** each type is correctly represented in JSON output
+**And** the `type` field accurately reflects the JavaScript type
+
+### AC4: Target a specific tab with --tab
+
+**Given** Chrome is running with multiple tabs open
+**When** I run `chrome-cli js exec --tab <ID> "document.title"`
+**Then** the JavaScript is executed in the specified tab
+**And** the `result` reflects that tab's page context
+
+### AC5: Await promise results (default behavior)
+
+**Given** Chrome is running with a page loaded
+**When** I run `chrome-cli js exec "new Promise(r => setTimeout(() => r('done'), 100))"`
+**Then** the `result` field is `"done"`
+**And** the promise was awaited before returning
+
+### AC6: Disable promise awaiting with --no-await
+
+**Given** Chrome is running with a page loaded
+**When** I run `chrome-cli js exec --no-await "new Promise(r => setTimeout(() => r('done'), 100))"`
+**Then** the `result` field represents the unresolved promise object
+**And** the `type` field is `"object"`
+
+### AC7: Execution timeout with --timeout
+
+**Given** Chrome is running with a page loaded
+**When** I run `chrome-cli js exec --timeout 100 "new Promise(() => {})"`
+**Then** stderr contains a JSON error indicating a timeout
+**And** the exit code is non-zero
+
+### AC8: Execute JavaScript from a file with --file
+
+**Given** Chrome is running with a page loaded
+**And** a file `/tmp/script.js` contains `document.title`
+**When** I run `chrome-cli js exec --file /tmp/script.js`
+**Then** the `result` field contains the page title
+**And** the behavior is identical to inline code execution
+
+### AC9: Read code from stdin with `-`
+
+**Given** Chrome is running with a page loaded
+**When** I run `echo "document.title" | chrome-cli js exec -`
+**Then** the `result` field contains the page title
+**And** stdin is read as the JavaScript code to execute
+
+### AC10: Element context execution with --uid
+
+**Given** Chrome is running with a page loaded
+**And** a snapshot has been taken with `chrome-cli page snapshot`
+**And** element `s1` exists in the snapshot
+**When** I run `chrome-cli js exec --uid s1 "(el) => el.textContent"`
+**Then** the function receives the DOM element as its first argument
+**And** the `result` field contains the element's text content
+
+### AC11: JavaScript exception handling
+
+**Given** Chrome is running with a page loaded
+**When** I run `chrome-cli js exec "throw new Error('test error')"`
+**Then** stderr contains a JSON error with `error` and `stack` fields
+**And** the `error` field contains `"Error: test error"`
+**And** the exit code is non-zero
+
+### AC12: Reference error handling
+
+**Given** Chrome is running with a page loaded
+**When** I run `chrome-cli js exec "nonExistentVariable"`
+**Then** stderr contains a JSON error indicating a ReferenceError
+**And** the exit code is non-zero
+
+### AC13: Large result truncation with --max-size
+
+**Given** Chrome is running with a page loaded
+**When** I run `chrome-cli js exec --max-size 100 "'x'.repeat(10000)"`
+**Then** the `result` field is truncated to approximately 100 bytes
+**And** a `truncated` field is set to `true` in the JSON output
+
+### AC14: UID not found error
+
+**Given** Chrome is running with a page loaded
+**And** no snapshot exists or the UID is invalid
+**When** I run `chrome-cli js exec --uid s999 "(el) => el.textContent"`
+**Then** stderr contains a JSON error indicating the UID was not found
+**And** the exit code is non-zero
+
+### AC15: File not found error
+
+**Given** Chrome is running with a page loaded
+**When** I run `chrome-cli js exec --file /nonexistent/script.js`
+**Then** stderr contains a JSON error indicating the file was not found
+**And** the exit code is non-zero
+
+### AC16: Console output capture
+
+**Given** Chrome is running with a page loaded
+**When** I run `chrome-cli js exec "console.log('hello'); 42"`
+**Then** the `result` field is `42`
+**And** a `console` field in the JSON output contains the captured console messages
+
+### Generated Gherkin Preview
+
+```gherkin
+Feature: JavaScript execution in page context
+  As a developer / automation engineer
+  I want to execute arbitrary JavaScript in the browser page context via the CLI
+  So that I can perform custom automation and data extraction from scripts
+
+  Background:
+    Given Chrome is running with CDP enabled
+
+  Scenario: Execute a JavaScript expression
+    Given a page is loaded at "https://example.com"
+    When I run "chrome-cli js exec 'document.title'"
+    Then stdout contains JSON with keys "result", "type"
+    And the "result" field is "Example Domain"
+    And the "type" field is "string"
+
+  Scenario: Execute a JavaScript function
+    Given a page is loaded
+    When I run "chrome-cli js exec '() => { return 2 + 2; }'"
+    Then the "result" field is 4
+    And the "type" field is "number"
+
+  Scenario Outline: Return all JavaScript value types
+    Given a page is loaded
+    When I run "chrome-cli js exec '<expression>'"
+    Then the "type" field is "<expected_type>"
+
+    Examples:
+      | expression            | expected_type |
+      | 'hello'               | string        |
+      | 42                    | number        |
+      | true                  | boolean       |
+      | null                  | object        |
+      | undefined             | undefined     |
+      | ({key: 'val'})        | object        |
+      | [1, 2, 3]             | object        |
+
+  Scenario: Target a specific tab
+    Given multiple tabs are open
+    When I run "chrome-cli js exec --tab <ID> 'document.title'"
+    Then the result reflects the targeted tab's context
+
+  Scenario: Await promise results by default
+    Given a page is loaded
+    When I run "chrome-cli js exec 'new Promise(r => setTimeout(() => r(\"done\"), 100))'"
+    Then the "result" field is "done"
+
+  Scenario: Disable promise awaiting
+    Given a page is loaded
+    When I run "chrome-cli js exec --no-await 'new Promise(r => r(42))'"
+    Then the "type" field is "object"
+
+  Scenario: Execution timeout
+    Given a page is loaded
+    When I run "chrome-cli js exec --timeout 100 'new Promise(() => {})'"
+    Then stderr contains a JSON error indicating timeout
+    And the exit code is non-zero
+
+  Scenario: Execute JavaScript from a file
+    Given a page is loaded
+    And a file "/tmp/script.js" contains "document.title"
+    When I run "chrome-cli js exec --file /tmp/script.js"
+    Then the "result" field contains the page title
+
+  Scenario: Read code from stdin
+    Given a page is loaded
+    When I pipe "document.title" to "chrome-cli js exec -"
+    Then the "result" field contains the page title
+
+  Scenario: Element context execution with UID
+    Given a page is loaded
+    And a snapshot has been taken
+    And element "s1" exists in the snapshot
+    When I run "chrome-cli js exec --uid s1 '(el) => el.textContent'"
+    Then the result contains the element's text content
+
+  Scenario: JavaScript exception returned as structured error
+    Given a page is loaded
+    When I run "chrome-cli js exec 'throw new Error(\"test error\")'"
+    Then stderr contains a JSON error with "error" and "stack" fields
+    And the exit code is non-zero
+
+  Scenario: Reference error handling
+    Given a page is loaded
+    When I run "chrome-cli js exec 'nonExistentVariable'"
+    Then stderr contains a JSON error indicating ReferenceError
+    And the exit code is non-zero
+
+  Scenario: Large result truncation
+    Given a page is loaded
+    When I run "chrome-cli js exec --max-size 100 \"'x'.repeat(10000)\""
+    Then the "result" field is truncated
+    And a "truncated" field is true
+
+  Scenario: UID not found error
+    Given a page is loaded
+    When I run "chrome-cli js exec --uid s999 '(el) => el.textContent'"
+    Then stderr contains a JSON error about UID not found
+    And the exit code is non-zero
+
+  Scenario: File not found error
+    Given a page is loaded
+    When I run "chrome-cli js exec --file /nonexistent/script.js"
+    Then stderr contains a JSON error about file not found
+    And the exit code is non-zero
+
+  Scenario: Console output capture
+    Given a page is loaded
+    When I run "chrome-cli js exec 'console.log(\"hello\"); 42'"
+    Then the "result" field is 42
+    And the "console" field contains "hello"
+```
+
+---
+
+## Functional Requirements
+
+| ID | Requirement | Priority | Notes |
+|----|-------------|----------|-------|
+| FR1 | `js exec <CODE>` executes JavaScript via `Runtime.evaluate` | Must | Core functionality |
+| FR2 | JSON output with `result` and `type` fields | Must | Default output format |
+| FR3 | `--tab <ID>` targets a specific tab | Must | Consistent with other commands |
+| FR4 | `--await` / `--no-await` controls promise handling (default: await) | Must | Async JavaScript support |
+| FR5 | `--timeout <MS>` overrides execution timeout | Must | Long-running script control |
+| FR6 | `--file <PATH>` reads JavaScript from a file | Must | Complex script support |
+| FR7 | `-` as code argument reads from stdin | Must | Pipeline integration |
+| FR8 | `--uid <UID>` passes element reference to function via `Runtime.callFunctionOn` | Must | Element context execution |
+| FR9 | JavaScript exceptions returned as structured errors with stack trace | Must | Debugging support |
+| FR10 | `--max-size <BYTES>` truncates large results | Should | Prevent overwhelming output |
+| FR11 | Console output captured during execution | Should | Debugging support |
+| FR12 | Handles all JS return types: string, number, boolean, null, undefined, object, array | Must | Complete type coverage |
+
+---
+
+## Non-Functional Requirements
+
+| Aspect | Requirement |
+|--------|-------------|
+| **Performance** | Expression evaluation completes within the `--timeout` window (default from global `--timeout` or 30s) |
+| **Security** | Power-user tool — no sandboxing needed since the user controls the browser. Local CDP only. |
+| **Reliability** | Graceful error on disconnected tabs, crashed pages, or pages mid-load |
+| **Platforms** | macOS, Linux, Windows (same as project baseline) |
+| **Output** | Errors to stderr as JSON, data to stdout; exit codes per `error.rs` conventions |
+
+---
+
+## Data Requirements
+
+### Input Data
+
+| Field | Type | Validation | Required |
+|-------|------|------------|----------|
+| `<CODE>` | String (positional) | Must be valid JavaScript or `-` for stdin | Yes (unless `--file`) |
+| `--file` | String (file path) | File must exist and be readable | No (mutually exclusive with `<CODE>`) |
+| `--tab` | String (tab ID) | Must resolve to a valid target | No (defaults to first page target) |
+| `--uid` | String (snapshot UID) | Must exist in current snapshot state | No |
+| `--timeout` | u64 (milliseconds) | Positive integer | No (inherits global timeout) |
+| `--max-size` | usize (bytes) | Positive integer | No (default: no truncation) |
+| `--no-await` | Boolean flag | N/A | No (default: await promises) |
+
+### Output Data (Success)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `result` | serde_json::Value | The JavaScript return value, serialized to JSON |
+| `type` | String | JavaScript type of the result (`"string"`, `"number"`, `"boolean"`, `"object"`, `"undefined"`) |
+| `console` | Array of objects | Console messages captured during execution (if any) |
+| `truncated` | Boolean | Present and `true` only when result was truncated by `--max-size` |
+
+### Output Data (Error)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `error` | String | Error description (e.g., `"ReferenceError: foo is not defined"`) |
+| `stack` | String | JavaScript stack trace (when available) |
+| `code` | u8 | Exit code |
+
+---
+
+## Dependencies
+
+### Internal Dependencies
+- [x] Issue #4 — CDP client (merged)
+- [x] Issue #6 — Session/connection management (merged)
+- [x] Issue #10 — Accessibility tree / snapshot (merged, needed for `--uid`)
+
+### Blocked By
+- None (all dependencies resolved)
+
+---
+
+## Out of Scope
+
+- Multi-expression batching (execute multiple scripts in sequence)
+- REPL / interactive JavaScript console mode
+- Source maps or TypeScript transpilation
+- Injecting scripts that persist across navigations (use `Page.addScriptToEvaluateOnNewDocument` later)
+- Execution in iframe contexts (main frame only for now)
+- Custom serialization of DOM elements in return values (elements returned as `{}`)
+
+---
+
+## Success Metrics
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| Type coverage | All 7 JS types handled | Test with each type |
+| Error fidelity | Exception message + stack trace returned | Test with throwing code |
+| Pipeline support | stdin and file input work | Test with `echo ... \| chrome-cli js exec -` |
+
+---
+
+## Open Questions
+
+- [x] ~~Should `--await` be the default?~~ — Yes, per the issue spec. Use `--no-await` to disable.
+- [x] ~~Should console capture be opt-in?~~ — Include by default when console messages are present; omit the field when empty.
+
+---
+
+## Validation Checklist
+
+- [x] User story follows "As a / I want / So that" format
+- [x] All acceptance criteria use Given/When/Then format
+- [x] No implementation details in requirements
+- [x] All criteria are testable and unambiguous
+- [x] Edge cases and error states are specified
+- [x] Dependencies are identified
+- [x] Out of scope is defined
+- [x] Open questions are documented (or resolved)

--- a/.claude/specs/js-execution/tasks.md
+++ b/.claude/specs/js-execution/tasks.md
@@ -1,0 +1,194 @@
+# Tasks: JavaScript Execution in Page Context
+
+**Issue**: #13
+**Date**: 2026-02-12
+**Status**: Planning
+**Author**: Claude (writing-specs)
+
+---
+
+## Summary
+
+| Phase | Tasks | Status |
+|-------|-------|--------|
+| Setup | 2 | [ ] |
+| Backend | 2 | [ ] |
+| Integration | 1 | [ ] |
+| Testing | 2 | [ ] |
+| **Total** | **7** | |
+
+---
+
+## Phase 1: Setup
+
+### T001: Add error helper constructors for JS execution
+
+**File(s)**: `src/error.rs`
+**Type**: Modify
+**Depends**: None
+**Acceptance**:
+- [ ] `AppError::js_execution_failed(description)` returns message `"JavaScript execution failed: {description}"` with `ExitCode::GeneralError`
+- [ ] `AppError::script_file_not_found(path)` returns message `"Script file not found: {path}"` with `ExitCode::GeneralError`
+- [ ] `AppError::script_file_read_failed(path, error)` returns message `"Failed to read script file: {path}: {error}"` with `ExitCode::GeneralError`
+- [ ] `AppError::no_js_code()` returns message `"No JavaScript code provided. Specify code as argument, --file, or pipe via stdin."` with `ExitCode::GeneralError`
+- [ ] Unit tests for all four constructors verify message content and exit code
+
+**Notes**: Follow the existing pattern of `evaluation_failed()`, `snapshot_failed()`, etc. The existing `evaluation_failed()` is specific to `page text` ("Text extraction failed"); the new `js_execution_failed()` uses generic wording.
+
+### T002: Add CLI argument types for `js exec`
+
+**File(s)**: `src/cli/mod.rs`
+**Type**: Modify
+**Depends**: None
+**Acceptance**:
+- [ ] `JsArgs` struct with `#[command(subcommand)]` field of type `JsCommand`
+- [ ] `JsCommand` enum with `Exec(JsExecArgs)` variant
+- [ ] `JsExecArgs` struct with fields:
+  - `code`: `Option<String>` — positional argument for inline JavaScript
+  - `--file`: `Option<PathBuf>` — path to JavaScript file
+  - `--uid`: `Option<String>` — element UID from snapshot
+  - `--no-await`: `bool` flag — disable promise awaiting
+  - `--timeout`: `Option<u64>` — execution timeout override in ms
+  - `--max-size`: `Option<usize>` — maximum result size in bytes
+- [ ] `code` and `--file` are mutually exclusive (via clap conflict)
+- [ ] `Command::Js` variant changed from unit to `Js(JsArgs)`
+- [ ] `cargo build` compiles without errors
+- [ ] `chrome-cli js exec --help` shows all options and global flags
+
+**Notes**: Follow the `PageArgs`/`PageCommand` and `PerfArgs`/`PerfCommand` patterns. The `--tab`, `--json`, `--pretty`, `--plain` flags are global and need no changes.
+
+---
+
+## Phase 2: Backend Implementation
+
+### T003: Implement JavaScript execution command
+
+**File(s)**: `src/js.rs` (new file)
+**Type**: Create
+**Depends**: T001, T002
+**Acceptance**:
+- [ ] `JsExecResult` struct with `result` (`serde_json::Value`), `type` (`String`), optional `console` (Vec of console entries), optional `truncated` (`bool`) — all with appropriate `skip_serializing_if`
+- [ ] `JsExecError` struct with `error` (`String`), optional `stack` (`String`), `code` (`u8`) for structured error output on stderr
+- [ ] `execute_js()` dispatches `JsCommand::Exec` to `execute_exec()`
+- [ ] `execute_exec()` follows the session setup pattern from `page.rs`:
+  - Resolves connection and target via `resolve_connection` / `resolve_target`
+  - Creates `CdpClient`, `CdpSession`, `ManagedSession`
+  - Enables `Runtime` domain via `ensure_domain`
+- [ ] Code resolution:
+  - `--file <PATH>`: reads file to string; returns `script_file_not_found` or `script_file_read_failed` on error
+  - `code == "-"`: reads stdin to string via `std::io::read_to_string(std::io::stdin())`
+  - `code == Some(expr)`: uses expression directly
+  - Neither code nor --file: returns `no_js_code` error
+- [ ] Without `--uid`: uses `Runtime.evaluate` with `returnByValue: true` and `awaitPromise: true` (unless `--no-await`)
+- [ ] With `--uid`:
+  - Reads snapshot state via `crate::snapshot::read_snapshot_state()`
+  - Resolves UID to `backendNodeId` from `uid_map`
+  - Enables `DOM` domain
+  - Calls `DOM.resolveNode({ backendNodeId })` to get `objectId`
+  - Calls `Runtime.callFunctionOn({ functionDeclaration, objectId, arguments: [{objectId}], returnByValue: true, awaitPromise: true })`
+- [ ] Exception handling:
+  - Checks `exceptionDetails` in CDP response
+  - Extracts `exception.description` and `exception.stackTrace` (or `text` fallback)
+  - Prints structured `JsExecError` JSON to stderr
+  - Returns `js_execution_failed` error
+- [ ] Result type extraction: maps CDP `result.type` and `result.subtype` to output `type` field
+- [ ] Console capture:
+  - Subscribes to `Runtime.consoleAPICalled` before execution
+  - Collects console messages during execution
+  - Includes in output as `console` array (omitted when empty)
+- [ ] `--max-size` truncation:
+  - Serializes result to JSON string
+  - If byte length exceeds limit, truncates and sets `truncated: true`
+- [ ] `print_output()` helper handles `--json` and `--pretty` (same pattern as `page.rs`)
+- [ ] `--plain` mode prints only the raw result value to stdout (string values unquoted, others JSON-encoded)
+- [ ] `cdp_config()` helper for timeout (same pattern as `page.rs`)
+- [ ] Unit tests for `JsExecResult` serialization (JSON fields present, skip_serializing_if works)
+- [ ] Unit tests for code resolution logic (file, stdin marker, inline, missing)
+
+**Notes**: The `DOM.resolveNode` → `Runtime.callFunctionOn` flow is new to the codebase. The existing `resolve_uid_clip` in `page.rs` uses `DOM.describeNode` to get a `nodeId`, but for `callFunctionOn` we need an `objectId` from `DOM.resolveNode` instead.
+
+### T004: Wire `js` command into main dispatcher
+
+**File(s)**: `src/main.rs`
+**Type**: Modify
+**Depends**: T003
+**Acceptance**:
+- [ ] `mod js;` declaration added
+- [ ] `Command::Js(args)` match arm calls `js::execute_js(&cli.global, args).await`
+- [ ] Previous `Err(AppError::not_implemented("js"))` is removed
+- [ ] `cargo build` compiles without errors
+- [ ] `cargo clippy` passes (all=deny, pedantic=warn)
+
+---
+
+## Phase 3: Integration
+
+### T005: Verify end-to-end with cargo clippy and existing tests
+
+**File(s)**: (all modified files)
+**Type**: Verify
+**Depends**: T004
+**Acceptance**:
+- [ ] `cargo clippy --all-targets -- -D warnings` passes with zero warnings
+- [ ] `cargo fmt --check` passes
+- [ ] `cargo test --lib` passes (all unit tests including new ones)
+- [ ] `cargo build` succeeds
+- [ ] `chrome-cli js exec --help` displays expected usage info
+- [ ] `chrome-cli js --help` shows the `exec` subcommand
+
+---
+
+## Phase 4: Testing
+
+### T006: Create BDD feature file for JavaScript execution
+
+**File(s)**: `tests/features/js-execution.feature`
+**Type**: Create
+**Depends**: T004
+**Acceptance**:
+- [ ] All 16 acceptance criteria from `requirements.md` are Gherkin scenarios
+- [ ] Uses `Background:` for shared Chrome setup
+- [ ] Valid Gherkin syntax
+- [ ] Scenarios are independent and declarative
+- [ ] Includes data-driven scenario outline for JS return types
+
+### T007: Implement BDD step definitions for JavaScript execution
+
+**File(s)**: `tests/bdd.rs`
+**Type**: Modify
+**Depends**: T006
+**Acceptance**:
+- [ ] Step definitions exist for all scenarios in `js-execution.feature`
+- [ ] Steps follow existing cucumber-rs patterns from the project
+- [ ] New steps are reusable where possible (e.g., "I run {string}" already exists)
+- [ ] `cargo test --test bdd` compiles (tests may skip if no Chrome available)
+
+---
+
+## Dependency Graph
+
+```
+T001 ──┐
+       ├──▶ T003 ──▶ T004 ──▶ T005
+T002 ──┘                │
+                        ├──▶ T006 ──▶ T007
+                        │
+                        └──▶ (done)
+```
+
+T001 and T002 can be done in parallel (no interdependency).
+T006 and T007 can proceed once T004 is complete.
+T005 is a verification gate before merging.
+
+---
+
+## Validation Checklist
+
+- [x] Each task has single responsibility
+- [x] Dependencies are correctly mapped
+- [x] Tasks can be completed independently (given dependencies)
+- [x] Acceptance criteria are verifiable
+- [x] File paths reference actual project structure (per `structure.md`)
+- [x] BDD test tasks included
+- [x] No circular dependencies
+- [x] Tasks are in logical execution order

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2,7 +2,7 @@
 
 use std::path::PathBuf;
 
-use clap::{Args, Parser, Subcommand, ValueEnum};
+use clap::{ArgAction, Args, Parser, Subcommand, ValueEnum};
 
 #[derive(Parser)]
 #[command(
@@ -124,7 +124,7 @@ pub enum Command {
             the result as structured JSON. Supports both synchronous expressions and async \
             functions."
     )]
-    Js,
+    Js(JsArgs),
 
     /// Console message reading and monitoring
     #[command(
@@ -461,6 +461,48 @@ pub struct PerfVitalsArgs {
     /// Path to save the trace file (default: auto-generated temp)
     #[arg(long)]
     pub file: Option<PathBuf>,
+}
+
+/// Arguments for the `js` subcommand group.
+#[derive(Args)]
+pub struct JsArgs {
+    #[command(subcommand)]
+    pub command: JsCommand,
+}
+
+/// JavaScript subcommands.
+#[derive(Subcommand)]
+pub enum JsCommand {
+    /// Execute JavaScript in the page context
+    Exec(JsExecArgs),
+}
+
+/// Arguments for `js exec`.
+#[derive(Args)]
+pub struct JsExecArgs {
+    /// JavaScript code to execute (use '-' to read from stdin)
+    #[arg(conflicts_with = "file")]
+    pub code: Option<String>,
+
+    /// Read JavaScript from a file
+    #[arg(long)]
+    pub file: Option<PathBuf>,
+
+    /// Element UID from snapshot; function receives element as first argument
+    #[arg(long)]
+    pub uid: Option<String>,
+
+    /// Do not await promise results
+    #[arg(long, action = ArgAction::SetTrue)]
+    pub no_await: bool,
+
+    /// Execution timeout override in milliseconds
+    #[arg(long)]
+    pub timeout: Option<u64>,
+
+    /// Truncate results exceeding this size in bytes
+    #[arg(long)]
+    pub max_size: Option<usize>,
 }
 
 /// Wait strategy for navigation commands.

--- a/src/error.rs
+++ b/src/error.rs
@@ -213,6 +213,40 @@ impl AppError {
     }
 
     #[must_use]
+    pub fn js_execution_failed(description: &str) -> Self {
+        Self {
+            message: format!("JavaScript execution failed: {description}"),
+            code: ExitCode::GeneralError,
+        }
+    }
+
+    #[must_use]
+    pub fn script_file_not_found(path: &str) -> Self {
+        Self {
+            message: format!("Script file not found: {path}"),
+            code: ExitCode::GeneralError,
+        }
+    }
+
+    #[must_use]
+    pub fn script_file_read_failed(path: &str, error: &str) -> Self {
+        Self {
+            message: format!("Failed to read script file: {path}: {error}"),
+            code: ExitCode::GeneralError,
+        }
+    }
+
+    #[must_use]
+    pub fn no_js_code() -> Self {
+        Self {
+            message:
+                "No JavaScript code provided. Specify code as argument, --file, or pipe via stdin."
+                    .into(),
+            code: ExitCode::GeneralError,
+        }
+    }
+
+    #[must_use]
     pub fn no_chrome_found() -> Self {
         Self {
             message: "No Chrome instance found. Run 'chrome-cli connect' or \
@@ -438,5 +472,39 @@ mod tests {
         assert!(err.message.contains("Trace timed out"));
         assert!(err.message.contains("30000ms"));
         assert!(matches!(err.code, ExitCode::TimeoutError));
+    }
+
+    #[test]
+    fn js_execution_failed_error() {
+        let err = AppError::js_execution_failed("ReferenceError: foo is not defined");
+        assert!(err.message.contains("JavaScript execution failed"));
+        assert!(err.message.contains("ReferenceError: foo is not defined"));
+        assert!(matches!(err.code, ExitCode::GeneralError));
+    }
+
+    #[test]
+    fn script_file_not_found_error() {
+        let err = AppError::script_file_not_found("/tmp/missing.js");
+        assert!(err.message.contains("Script file not found"));
+        assert!(err.message.contains("/tmp/missing.js"));
+        assert!(matches!(err.code, ExitCode::GeneralError));
+    }
+
+    #[test]
+    fn script_file_read_failed_error() {
+        let err = AppError::script_file_read_failed("/tmp/bad.js", "permission denied");
+        assert!(err.message.contains("Failed to read script file"));
+        assert!(err.message.contains("/tmp/bad.js"));
+        assert!(err.message.contains("permission denied"));
+        assert!(matches!(err.code, ExitCode::GeneralError));
+    }
+
+    #[test]
+    fn no_js_code_error() {
+        let err = AppError::no_js_code();
+        assert!(err.message.contains("No JavaScript code provided"));
+        assert!(err.message.contains("--file"));
+        assert!(err.message.contains("stdin"));
+        assert!(matches!(err.code, ExitCode::GeneralError));
     }
 }

--- a/src/js.rs
+++ b/src/js.rs
@@ -1,0 +1,871 @@
+use std::time::Duration;
+
+use serde::Serialize;
+
+use chrome_cli::cdp::{CdpClient, CdpConfig};
+use chrome_cli::connection::{ManagedSession, resolve_connection, resolve_target};
+use chrome_cli::error::{AppError, ExitCode};
+
+use crate::cli::{GlobalOpts, JsArgs, JsCommand, JsExecArgs};
+
+// =============================================================================
+// Output types
+// =============================================================================
+
+#[derive(Debug, Serialize)]
+struct JsExecResult {
+    result: serde_json::Value,
+    r#type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    console: Option<Vec<ConsoleEntry>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    truncated: Option<bool>,
+}
+
+#[derive(Debug, Serialize)]
+struct ConsoleEntry {
+    level: String,
+    text: String,
+}
+
+#[derive(Debug, Serialize)]
+struct JsExecError {
+    error: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    stack: Option<String>,
+    code: u8,
+}
+
+// =============================================================================
+// Output formatting
+// =============================================================================
+
+fn print_output(value: &impl Serialize, output: &crate::cli::OutputFormat) -> Result<(), AppError> {
+    let json = if output.pretty {
+        serde_json::to_string_pretty(value)
+    } else {
+        serde_json::to_string(value)
+    };
+    let json = json.map_err(|e| AppError {
+        message: format!("serialization error: {e}"),
+        code: ExitCode::GeneralError,
+    })?;
+    println!("{json}");
+    Ok(())
+}
+
+// =============================================================================
+// Config helper
+// =============================================================================
+
+fn cdp_config(global: &GlobalOpts, exec_args: &JsExecArgs) -> CdpConfig {
+    let mut config = CdpConfig::default();
+    // Execution-specific --timeout overrides global --timeout
+    #[allow(clippy::cast_possible_truncation)]
+    let default_timeout = config.command_timeout.as_millis() as u64;
+    let timeout_ms = exec_args
+        .timeout
+        .or(global.timeout)
+        .unwrap_or(default_timeout);
+    config.command_timeout = Duration::from_millis(timeout_ms);
+    config
+}
+
+// =============================================================================
+// Dispatcher
+// =============================================================================
+
+/// Execute the `js` subcommand group.
+///
+/// # Errors
+///
+/// Returns `AppError` if the subcommand fails.
+pub async fn execute_js(global: &GlobalOpts, args: &JsArgs) -> Result<(), AppError> {
+    match &args.command {
+        JsCommand::Exec(exec_args) => execute_exec(global, exec_args).await,
+    }
+}
+
+// =============================================================================
+// Session setup
+// =============================================================================
+
+async fn setup_session(
+    global: &GlobalOpts,
+    exec_args: &JsExecArgs,
+) -> Result<(CdpClient, ManagedSession), AppError> {
+    let conn = resolve_connection(&global.host, global.port, global.ws_url.as_deref()).await?;
+    let target = resolve_target(&conn.host, conn.port, global.tab.as_deref()).await?;
+
+    let config = cdp_config(global, exec_args);
+    let client = CdpClient::connect(&conn.ws_url, config).await?;
+    let session = client.create_session(&target.id).await?;
+    let managed = ManagedSession::new(session);
+
+    Ok((client, managed))
+}
+
+// =============================================================================
+// Code resolution
+// =============================================================================
+
+/// Resolve the JavaScript code to execute from the various input sources.
+fn resolve_code(args: &JsExecArgs) -> Result<String, AppError> {
+    if let Some(ref path) = args.file {
+        // --file <PATH>
+        let path_str = path.display().to_string();
+        if !path.exists() {
+            return Err(AppError::script_file_not_found(&path_str));
+        }
+        std::fs::read_to_string(path)
+            .map_err(|e| AppError::script_file_read_failed(&path_str, &e.to_string()))
+    } else if let Some(ref code) = args.code {
+        if code == "-" {
+            // Read from stdin
+            std::io::read_to_string(std::io::stdin())
+                .map_err(|e| AppError::script_file_read_failed("stdin", &e.to_string()))
+        } else {
+            Ok(code.clone())
+        }
+    } else {
+        Err(AppError::no_js_code())
+    }
+}
+
+// =============================================================================
+// Result type mapping
+// =============================================================================
+
+/// Map CDP result type/subtype to the JavaScript type string for our output.
+fn js_type_string(result: &serde_json::Value) -> String {
+    let type_str = result["type"].as_str().unwrap_or("undefined");
+    match type_str {
+        "undefined" => "undefined".to_string(),
+        "string" => "string".to_string(),
+        "number" => "number".to_string(),
+        "boolean" => "boolean".to_string(),
+        "object" | "function" => type_str.to_string(),
+        other => other.to_string(),
+    }
+}
+
+/// Extract the result value from a CDP evaluate/callFunctionOn response.
+fn extract_result_value(result: &serde_json::Value) -> serde_json::Value {
+    let type_str = result["type"].as_str().unwrap_or("undefined");
+    match type_str {
+        "undefined" => serde_json::Value::Null,
+        _ => {
+            if result.get("value").is_some() {
+                result["value"].clone()
+            } else {
+                // For objects that can't be serialized by value (e.g., promises with --no-await)
+                let subtype = result["subtype"].as_str().unwrap_or("");
+                let description = result["description"].as_str().unwrap_or("{}");
+                if subtype.is_empty() {
+                    serde_json::Value::String(description.to_string())
+                } else {
+                    serde_json::Value::String(format!("[{subtype}: {description}]"))
+                }
+            }
+        }
+    }
+}
+
+// =============================================================================
+// Truncation
+// =============================================================================
+
+/// Apply `--max-size` truncation to a result. Returns (possibly truncated value, was truncated).
+fn apply_truncation(
+    value: serde_json::Value,
+    max_size: Option<usize>,
+) -> (serde_json::Value, bool) {
+    let Some(max) = max_size else {
+        return (value, false);
+    };
+
+    let serialized = serde_json::to_string(&value).unwrap_or_default();
+    if serialized.len() <= max {
+        return (value, false);
+    }
+
+    // For strings, truncate the string content
+    if let Some(s) = value.as_str() {
+        // Truncate to approximately max bytes
+        let truncated: String = s.chars().take(max).collect();
+        (serde_json::Value::String(truncated), true)
+    } else {
+        // For non-strings, truncate the serialized form
+        let truncated = &serialized[..max.min(serialized.len())];
+        // Try to return a valid JSON value; fall back to string
+        if let Ok(v) = serde_json::from_str(truncated) {
+            (v, true)
+        } else {
+            (serde_json::Value::String(truncated.to_string()), true)
+        }
+    }
+}
+
+// =============================================================================
+// Console capture
+// =============================================================================
+
+/// Extract console entries from collected Runtime.consoleAPICalled events.
+fn extract_console_entries(events: &[serde_json::Value]) -> Vec<ConsoleEntry> {
+    events
+        .iter()
+        .filter_map(|params| {
+            let level = params["type"].as_str().unwrap_or("log").to_string();
+            let args = params["args"].as_array()?;
+            let text = args
+                .iter()
+                .filter_map(|arg| {
+                    arg["value"].as_str().map(String::from).or_else(|| {
+                        // For non-string values, use the description or JSON representation
+                        arg["description"]
+                            .as_str()
+                            .map(String::from)
+                            .or_else(|| serde_json::to_string(&arg["value"]).ok())
+                    })
+                })
+                .collect::<Vec<_>>()
+                .join(" ");
+            Some(ConsoleEntry { level, text })
+        })
+        .collect()
+}
+
+// =============================================================================
+// Execution
+// =============================================================================
+
+#[allow(clippy::too_many_lines)]
+async fn execute_exec(global: &GlobalOpts, args: &JsExecArgs) -> Result<(), AppError> {
+    let code = resolve_code(args)?;
+    let (_client, mut managed) = setup_session(global, args).await?;
+
+    // Enable Runtime domain
+    managed.ensure_domain("Runtime").await?;
+
+    // Subscribe to console events before execution
+    let mut console_rx = managed
+        .subscribe("Runtime.consoleAPICalled")
+        .await
+        .map_err(|e| AppError {
+            message: format!("Failed to subscribe to console events: {e}"),
+            code: ExitCode::GeneralError,
+        })?;
+
+    let await_promise = !args.no_await;
+
+    // Execute based on whether --uid is provided
+    let result = if let Some(ref uid) = args.uid {
+        // Element context execution via Runtime.callFunctionOn
+        execute_with_uid(&mut managed, &code, uid, await_promise).await?
+    } else {
+        // Expression evaluation via Runtime.evaluate
+        execute_expression(&managed, &code, await_promise).await?
+    };
+
+    // Collect console events (drain with a short timeout)
+    let mut console_events = Vec::new();
+    let drain_deadline = tokio::time::Instant::now() + tokio::time::Duration::from_millis(100);
+    loop {
+        let remaining = drain_deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+        match tokio::time::timeout(remaining, console_rx.recv()).await {
+            Ok(Some(event)) => console_events.push(event.params),
+            Ok(None) | Err(_) => break,
+        }
+    }
+
+    // Check for exception
+    if let Some(exception_details) = result.get("exceptionDetails") {
+        let exception = &exception_details["exception"];
+        let error_desc = exception["description"]
+            .as_str()
+            .or_else(|| exception_details["text"].as_str())
+            .unwrap_or("unknown error")
+            .to_string();
+
+        // Build stack trace string
+        let stack = exception["description"]
+            .as_str()
+            .map(String::from)
+            .or_else(|| {
+                exception_details["stackTrace"]["callFrames"]
+                    .as_array()
+                    .map(|frames| {
+                        frames
+                            .iter()
+                            .map(|f| {
+                                let func = f["functionName"].as_str().unwrap_or("<anonymous>");
+                                let line = f["lineNumber"].as_i64().unwrap_or(0);
+                                let col = f["columnNumber"].as_i64().unwrap_or(0);
+                                format!("    at {func} (<anonymous>:{line}:{col})")
+                            })
+                            .collect::<Vec<_>>()
+                            .join("\n")
+                    })
+            });
+
+        let js_error = JsExecError {
+            error: error_desc.clone(),
+            stack,
+            code: ExitCode::GeneralError as u8,
+        };
+        let err_json = serde_json::to_string(&js_error)
+            .unwrap_or_else(|_| format!(r#"{{"error":"{error_desc}","code":1}}"#));
+        eprintln!("{err_json}");
+        return Err(AppError::js_execution_failed(&error_desc));
+    }
+
+    // Extract result value and type
+    let cdp_result = &result["result"];
+    let js_type = js_type_string(cdp_result);
+    let value = extract_result_value(cdp_result);
+
+    // Apply truncation
+    let (value, was_truncated) = apply_truncation(value, args.max_size);
+
+    // Build console entries
+    let console_entries = extract_console_entries(&console_events);
+
+    let output = JsExecResult {
+        result: value.clone(),
+        r#type: js_type,
+        console: if console_entries.is_empty() {
+            None
+        } else {
+            Some(console_entries)
+        },
+        truncated: if was_truncated { Some(true) } else { None },
+    };
+
+    // Output
+    if global.output.plain {
+        // Plain mode: print raw value
+        match &value {
+            serde_json::Value::String(s) => print!("{s}"),
+            serde_json::Value::Null => print!("undefined"),
+            other => {
+                let s = serde_json::to_string(other).unwrap_or_default();
+                print!("{s}");
+            }
+        }
+        return Ok(());
+    }
+
+    print_output(&output, &global.output)
+}
+
+/// Execute a JavaScript expression via Runtime.evaluate.
+async fn execute_expression(
+    managed: &ManagedSession,
+    code: &str,
+    await_promise: bool,
+) -> Result<serde_json::Value, AppError> {
+    let params = serde_json::json!({
+        "expression": code,
+        "returnByValue": true,
+        "awaitPromise": await_promise,
+        "generatePreview": true,
+    });
+
+    managed
+        .send_command("Runtime.evaluate", Some(params))
+        .await
+        .map_err(|e| {
+            // Check if it's a timeout error
+            let err_str = format!("{e:?}");
+            if err_str.contains("CommandTimeout") {
+                AppError {
+                    message: format!("JavaScript execution timed out: {e}"),
+                    code: ExitCode::TimeoutError,
+                }
+            } else {
+                AppError {
+                    message: format!("JavaScript execution failed: {e}"),
+                    code: ExitCode::GeneralError,
+                }
+            }
+        })
+}
+
+/// Execute a function with an element context via Runtime.callFunctionOn.
+async fn execute_with_uid(
+    managed: &mut ManagedSession,
+    code: &str,
+    uid: &str,
+    await_promise: bool,
+) -> Result<serde_json::Value, AppError> {
+    // Read snapshot state to get backendNodeId
+    let state = crate::snapshot::read_snapshot_state()
+        .map_err(|e| AppError {
+            message: format!("Failed to read snapshot state: {e}"),
+            code: ExitCode::GeneralError,
+        })?
+        .ok_or_else(|| AppError {
+            message: "No snapshot state found. Run 'chrome-cli page snapshot' first.".to_string(),
+            code: ExitCode::GeneralError,
+        })?;
+
+    let backend_node_id = state
+        .uid_map
+        .get(uid)
+        .ok_or_else(|| AppError::uid_not_found(uid))?;
+
+    // Enable DOM domain for resolveNode
+    managed.ensure_domain("DOM").await?;
+
+    // Resolve backendNodeId to a remote objectId
+    let resolve_result = managed
+        .send_command(
+            "DOM.resolveNode",
+            Some(serde_json::json!({ "backendNodeId": backend_node_id })),
+        )
+        .await
+        .map_err(|e| AppError {
+            message: format!("Failed to resolve UID '{uid}': {e}"),
+            code: ExitCode::GeneralError,
+        })?;
+
+    let object_id = resolve_result["object"]["objectId"]
+        .as_str()
+        .ok_or_else(|| AppError {
+            message: format!("UID '{uid}' could not be resolved to a DOM object"),
+            code: ExitCode::GeneralError,
+        })?;
+
+    // Call the function on the resolved element
+    let params = serde_json::json!({
+        "functionDeclaration": code,
+        "objectId": object_id,
+        "arguments": [{ "objectId": object_id }],
+        "returnByValue": true,
+        "awaitPromise": await_promise,
+    });
+
+    managed
+        .send_command("Runtime.callFunctionOn", Some(params))
+        .await
+        .map_err(|e| {
+            let err_str = format!("{e:?}");
+            if err_str.contains("CommandTimeout") {
+                AppError {
+                    message: format!("JavaScript execution timed out: {e}"),
+                    code: ExitCode::TimeoutError,
+                }
+            } else {
+                AppError {
+                    message: format!("JavaScript execution failed: {e}"),
+                    code: ExitCode::GeneralError,
+                }
+            }
+        })
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // =========================================================================
+    // JsExecResult serialization tests
+    // =========================================================================
+
+    #[test]
+    fn js_exec_result_basic_string() {
+        let result = JsExecResult {
+            result: serde_json::Value::String("hello".to_string()),
+            r#type: "string".to_string(),
+            console: None,
+            truncated: None,
+        };
+        let json: serde_json::Value = serde_json::to_value(&result).unwrap();
+        assert_eq!(json["result"], "hello");
+        assert_eq!(json["type"], "string");
+        assert!(json.get("console").is_none());
+        assert!(json.get("truncated").is_none());
+    }
+
+    #[test]
+    fn js_exec_result_number() {
+        let result = JsExecResult {
+            result: serde_json::json!(42),
+            r#type: "number".to_string(),
+            console: None,
+            truncated: None,
+        };
+        let json: serde_json::Value = serde_json::to_value(&result).unwrap();
+        assert_eq!(json["result"], 42);
+        assert_eq!(json["type"], "number");
+    }
+
+    #[test]
+    fn js_exec_result_with_console() {
+        let result = JsExecResult {
+            result: serde_json::json!(42),
+            r#type: "number".to_string(),
+            console: Some(vec![ConsoleEntry {
+                level: "log".to_string(),
+                text: "hello".to_string(),
+            }]),
+            truncated: None,
+        };
+        let json: serde_json::Value = serde_json::to_value(&result).unwrap();
+        assert_eq!(json["result"], 42);
+        let console = json["console"].as_array().unwrap();
+        assert_eq!(console.len(), 1);
+        assert_eq!(console[0]["level"], "log");
+        assert_eq!(console[0]["text"], "hello");
+    }
+
+    #[test]
+    fn js_exec_result_with_truncation() {
+        let result = JsExecResult {
+            result: serde_json::Value::String("truncated...".to_string()),
+            r#type: "string".to_string(),
+            console: None,
+            truncated: Some(true),
+        };
+        let json: serde_json::Value = serde_json::to_value(&result).unwrap();
+        assert_eq!(json["truncated"], true);
+    }
+
+    #[test]
+    fn js_exec_result_object_type() {
+        let result = JsExecResult {
+            result: serde_json::json!({"key": "val"}),
+            r#type: "object".to_string(),
+            console: None,
+            truncated: None,
+        };
+        let json: serde_json::Value = serde_json::to_value(&result).unwrap();
+        assert_eq!(json["result"]["key"], "val");
+        assert_eq!(json["type"], "object");
+    }
+
+    #[test]
+    fn js_exec_result_null_value() {
+        let result = JsExecResult {
+            result: serde_json::Value::Null,
+            r#type: "object".to_string(),
+            console: None,
+            truncated: None,
+        };
+        let json: serde_json::Value = serde_json::to_value(&result).unwrap();
+        assert!(json["result"].is_null());
+        assert_eq!(json["type"], "object");
+    }
+
+    #[test]
+    fn js_exec_result_undefined_type() {
+        let result = JsExecResult {
+            result: serde_json::Value::Null,
+            r#type: "undefined".to_string(),
+            console: None,
+            truncated: None,
+        };
+        let json: serde_json::Value = serde_json::to_value(&result).unwrap();
+        assert_eq!(json["type"], "undefined");
+    }
+
+    #[test]
+    fn js_exec_result_boolean() {
+        let result = JsExecResult {
+            result: serde_json::json!(true),
+            r#type: "boolean".to_string(),
+            console: None,
+            truncated: None,
+        };
+        let json: serde_json::Value = serde_json::to_value(&result).unwrap();
+        assert_eq!(json["result"], true);
+        assert_eq!(json["type"], "boolean");
+    }
+
+    #[test]
+    fn js_exec_result_array() {
+        let result = JsExecResult {
+            result: serde_json::json!([1, 2, 3]),
+            r#type: "object".to_string(),
+            console: None,
+            truncated: None,
+        };
+        let json: serde_json::Value = serde_json::to_value(&result).unwrap();
+        let arr = json["result"].as_array().unwrap();
+        assert_eq!(arr.len(), 3);
+        assert_eq!(json["type"], "object");
+    }
+
+    // =========================================================================
+    // JsExecError serialization tests
+    // =========================================================================
+
+    #[test]
+    fn js_exec_error_serialization() {
+        let err = JsExecError {
+            error: "ReferenceError: foo is not defined".to_string(),
+            stack: Some("ReferenceError: foo is not defined\n    at <anonymous>:1:1".to_string()),
+            code: 1,
+        };
+        let json: serde_json::Value = serde_json::to_value(&err).unwrap();
+        assert_eq!(json["error"], "ReferenceError: foo is not defined");
+        assert!(json["stack"].as_str().unwrap().contains("<anonymous>:1:1"));
+        assert_eq!(json["code"], 1);
+    }
+
+    #[test]
+    fn js_exec_error_without_stack() {
+        let err = JsExecError {
+            error: "Error occurred".to_string(),
+            stack: None,
+            code: 1,
+        };
+        let json: serde_json::Value = serde_json::to_value(&err).unwrap();
+        assert_eq!(json["error"], "Error occurred");
+        assert!(json.get("stack").is_none());
+    }
+
+    // =========================================================================
+    // js_type_string tests
+    // =========================================================================
+
+    #[test]
+    fn js_type_string_all_types() {
+        assert_eq!(
+            js_type_string(&serde_json::json!({"type": "string"})),
+            "string"
+        );
+        assert_eq!(
+            js_type_string(&serde_json::json!({"type": "number"})),
+            "number"
+        );
+        assert_eq!(
+            js_type_string(&serde_json::json!({"type": "boolean"})),
+            "boolean"
+        );
+        assert_eq!(
+            js_type_string(&serde_json::json!({"type": "object"})),
+            "object"
+        );
+        assert_eq!(
+            js_type_string(&serde_json::json!({"type": "undefined"})),
+            "undefined"
+        );
+        assert_eq!(
+            js_type_string(&serde_json::json!({"type": "function"})),
+            "function"
+        );
+    }
+
+    #[test]
+    fn js_type_string_missing_defaults_to_undefined() {
+        assert_eq!(js_type_string(&serde_json::json!({})), "undefined");
+    }
+
+    // =========================================================================
+    // extract_result_value tests
+    // =========================================================================
+
+    #[test]
+    fn extract_result_value_string() {
+        let result = serde_json::json!({"type": "string", "value": "hello"});
+        assert_eq!(
+            extract_result_value(&result),
+            serde_json::Value::String("hello".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_result_value_number() {
+        let result = serde_json::json!({"type": "number", "value": 42});
+        assert_eq!(extract_result_value(&result), serde_json::json!(42));
+    }
+
+    #[test]
+    fn extract_result_value_boolean() {
+        let result = serde_json::json!({"type": "boolean", "value": true});
+        assert_eq!(extract_result_value(&result), serde_json::json!(true));
+    }
+
+    #[test]
+    fn extract_result_value_null() {
+        let result = serde_json::json!({"type": "object", "subtype": "null", "value": null});
+        assert_eq!(extract_result_value(&result), serde_json::Value::Null);
+    }
+
+    #[test]
+    fn extract_result_value_undefined() {
+        let result = serde_json::json!({"type": "undefined"});
+        assert_eq!(extract_result_value(&result), serde_json::Value::Null);
+    }
+
+    #[test]
+    fn extract_result_value_object_with_value() {
+        let result = serde_json::json!({"type": "object", "value": {"key": "val"}});
+        assert_eq!(
+            extract_result_value(&result),
+            serde_json::json!({"key": "val"})
+        );
+    }
+
+    #[test]
+    fn extract_result_value_object_without_value() {
+        let result =
+            serde_json::json!({"type": "object", "subtype": "promise", "description": "Promise"});
+        assert_eq!(
+            extract_result_value(&result),
+            serde_json::Value::String("[promise: Promise]".to_string())
+        );
+    }
+
+    // =========================================================================
+    // apply_truncation tests
+    // =========================================================================
+
+    #[test]
+    fn truncation_not_applied_when_none() {
+        let value = serde_json::Value::String("hello".to_string());
+        let (result, truncated) = apply_truncation(value.clone(), None);
+        assert_eq!(result, value);
+        assert!(!truncated);
+    }
+
+    #[test]
+    fn truncation_not_applied_when_within_limit() {
+        let value = serde_json::Value::String("hello".to_string());
+        let (result, truncated) = apply_truncation(value.clone(), Some(1000));
+        assert_eq!(result, value);
+        assert!(!truncated);
+    }
+
+    #[test]
+    fn truncation_applied_to_long_string() {
+        let long_str: String = "x".repeat(10000);
+        let value = serde_json::Value::String(long_str);
+        let (result, truncated) = apply_truncation(value, Some(100));
+        assert!(truncated);
+        let s = result.as_str().unwrap();
+        assert_eq!(s.len(), 100);
+    }
+
+    // =========================================================================
+    // extract_console_entries tests
+    // =========================================================================
+
+    #[test]
+    fn extract_console_entries_log() {
+        let events = vec![serde_json::json!({
+            "type": "log",
+            "args": [{"type": "string", "value": "hello"}]
+        })];
+        let entries = extract_console_entries(&events);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].level, "log");
+        assert_eq!(entries[0].text, "hello");
+    }
+
+    #[test]
+    fn extract_console_entries_multiple_args() {
+        let events = vec![serde_json::json!({
+            "type": "log",
+            "args": [
+                {"type": "string", "value": "hello"},
+                {"type": "string", "value": "world"}
+            ]
+        })];
+        let entries = extract_console_entries(&events);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].text, "hello world");
+    }
+
+    #[test]
+    fn extract_console_entries_empty() {
+        let events: Vec<serde_json::Value> = vec![];
+        let entries = extract_console_entries(&events);
+        assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn extract_console_entries_warn_level() {
+        let events = vec![serde_json::json!({
+            "type": "warning",
+            "args": [{"type": "string", "value": "oops"}]
+        })];
+        let entries = extract_console_entries(&events);
+        assert_eq!(entries[0].level, "warning");
+    }
+
+    // =========================================================================
+    // resolve_code tests (basic — file and stdin can't easily be tested here)
+    // =========================================================================
+
+    #[test]
+    fn resolve_code_inline() {
+        let args = JsExecArgs {
+            code: Some("document.title".to_string()),
+            file: None,
+            uid: None,
+            no_await: false,
+            timeout: None,
+            max_size: None,
+        };
+        let code = resolve_code(&args).unwrap();
+        assert_eq!(code, "document.title");
+    }
+
+    #[test]
+    fn resolve_code_no_input() {
+        let args = JsExecArgs {
+            code: None,
+            file: None,
+            uid: None,
+            no_await: false,
+            timeout: None,
+            max_size: None,
+        };
+        let err = resolve_code(&args).unwrap_err();
+        assert!(err.message.contains("No JavaScript code provided"));
+    }
+
+    #[test]
+    fn resolve_code_file_not_found() {
+        let args = JsExecArgs {
+            code: None,
+            file: Some(std::path::PathBuf::from("/nonexistent/script.js")),
+            uid: None,
+            no_await: false,
+            timeout: None,
+            max_size: None,
+        };
+        let err = resolve_code(&args).unwrap_err();
+        assert!(err.message.contains("Script file not found"));
+    }
+
+    #[test]
+    fn resolve_code_from_file() {
+        let dir = std::env::temp_dir().join("chrome-cli-test-js-resolve");
+        let _ = std::fs::create_dir_all(&dir);
+        let path = dir.join("test.js");
+        std::fs::write(&path, "document.title").unwrap();
+
+        let args = JsExecArgs {
+            code: None,
+            file: Some(path),
+            uid: None,
+            no_await: false,
+            timeout: None,
+            max_size: None,
+        };
+        let code = resolve_code(&args).unwrap();
+        assert_eq!(code, "document.title");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod cli;
+mod js;
 mod navigate;
 mod page;
 mod perf;
@@ -38,7 +39,7 @@ async fn run(cli: &Cli) -> Result<(), AppError> {
         Command::Navigate(args) => navigate::execute_navigate(&cli.global, args).await,
         Command::Page(args) => page::execute_page(&cli.global, args).await,
         Command::Dom => Err(AppError::not_implemented("dom")),
-        Command::Js => Err(AppError::not_implemented("js")),
+        Command::Js(args) => js::execute_js(&cli.global, args).await,
         Command::Console => Err(AppError::not_implemented("console")),
         Command::Network => Err(AppError::not_implemented("network")),
         Command::Interact => Err(AppError::not_implemented("interact")),

--- a/tests/features/cli-skeleton.feature
+++ b/tests/features/cli-skeleton.feature
@@ -60,7 +60,6 @@ Feature: CLI skeleton with clap derive macros and top-level help
     Examples:
       | subcommand |
       | dom        |
-      | js         |
       | console    |
       | network    |
       | interact   |
@@ -107,6 +106,6 @@ Feature: CLI skeleton with clap derive macros and top-level help
 
   Scenario: Tab ID option is accepted
     Given chrome-cli is built
-    When I run "chrome-cli --tab abc123 js"
+    When I run "chrome-cli --tab abc123 js exec --file /nonexistent/file.js"
     Then the exit code should be 1
-    And stderr should contain "not yet implemented"
+    And stderr should contain "Script file not found"

--- a/tests/features/js-execution.feature
+++ b/tests/features/js-execution.feature
@@ -1,0 +1,141 @@
+# File: tests/features/js-execution.feature
+#
+# Generated from: .claude/specs/js-execution/requirements.md
+# Issue: #13
+
+Feature: JavaScript execution in page context
+  As a developer / automation engineer
+  I want to execute arbitrary JavaScript in the browser page context via the CLI
+  So that I can perform custom automation and data extraction from scripts
+
+  Background:
+    Given Chrome is running with CDP enabled
+
+  # --- Happy Path ---
+
+  Scenario: Execute a JavaScript expression
+    Given a page is loaded at "https://example.com"
+    When I run "chrome-cli js exec 'document.title'"
+    Then stdout contains JSON with keys "result", "type"
+    And the "result" field is "Example Domain"
+    And the "type" field is "string"
+
+  Scenario: Execute a JavaScript function
+    Given a page is loaded at "https://example.com"
+    When I run "chrome-cli js exec '() => { return 2 + 2; }'"
+    Then the "result" field is 4
+    And the "type" field is "number"
+
+  Scenario Outline: Return all JavaScript value types
+    Given a page is loaded at "https://example.com"
+    When I run "chrome-cli js exec '<expression>'"
+    Then the "type" field is "<expected_type>"
+
+    Examples:
+      | expression            | expected_type |
+      | 'hello'               | string        |
+      | 42                    | number        |
+      | true                  | boolean       |
+      | null                  | object        |
+      | undefined             | undefined     |
+      | ({key: 'val'})        | object        |
+      | [1, 2, 3]             | object        |
+
+  # --- Tab Targeting ---
+
+  Scenario: Target a specific tab with --tab
+    Given multiple tabs are open
+    And the second tab is loaded at "https://example.org"
+    When I run "chrome-cli js exec --tab <SECOND_TAB_ID> 'document.title'"
+    Then the "result" field reflects the second tab's title
+
+  # --- Promise Handling ---
+
+  Scenario: Await promise results by default
+    Given a page is loaded at "https://example.com"
+    When I run "chrome-cli js exec 'new Promise(r => setTimeout(() => r(\"done\"), 100))'"
+    Then the "result" field is "done"
+    And the "type" field is "string"
+
+  Scenario: Disable promise awaiting with --no-await
+    Given a page is loaded at "https://example.com"
+    When I run "chrome-cli js exec --no-await 'new Promise(r => r(42))'"
+    Then the "type" field is "object"
+
+  # --- Timeout ---
+
+  Scenario: Execution timeout with --timeout
+    Given a page is loaded at "https://example.com"
+    When I run "chrome-cli js exec --timeout 100 'new Promise(() => {})'"
+    Then stderr contains a JSON error indicating timeout
+    And the exit code is non-zero
+
+  # --- File and Stdin Input ---
+
+  Scenario: Execute JavaScript from a file
+    Given a page is loaded at "https://example.com"
+    And a temporary file contains "document.title"
+    When I run "chrome-cli js exec --file <TEMP_FILE>"
+    Then the "result" field is "Example Domain"
+    And the "type" field is "string"
+
+  Scenario: Read code from stdin with dash argument
+    Given a page is loaded at "https://example.com"
+    When I pipe "document.title" to "chrome-cli js exec -"
+    Then the "result" field is "Example Domain"
+    And the "type" field is "string"
+
+  # --- Element Context ---
+
+  Scenario: Element context execution with --uid
+    Given a page is loaded at "https://example.com"
+    And a snapshot has been taken with "chrome-cli page snapshot"
+    And element "s1" exists in the snapshot
+    When I run "chrome-cli js exec --uid s1 '(el) => el.textContent'"
+    Then the "result" field contains the element's text content
+    And the "type" field is "string"
+
+  # --- Error Handling ---
+
+  Scenario: JavaScript exception returned as structured error
+    Given a page is loaded at "https://example.com"
+    When I run "chrome-cli js exec 'throw new Error(\"test error\")'"
+    Then stderr contains a JSON error with key "error"
+    And the error message contains "Error: test error"
+    And the exit code is non-zero
+
+  Scenario: Reference error for undefined variable
+    Given a page is loaded at "https://example.com"
+    When I run "chrome-cli js exec 'nonExistentVariable'"
+    Then stderr contains a JSON error
+    And the error message contains "ReferenceError"
+    And the exit code is non-zero
+
+  Scenario: UID not found error
+    Given a page is loaded at "https://example.com"
+    When I run "chrome-cli js exec --uid s999 '(el) => el.textContent'"
+    Then stderr contains a JSON error about UID not found
+    And the exit code is non-zero
+
+  Scenario: File not found error
+    Given a page is loaded at "https://example.com"
+    When I run "chrome-cli js exec --file /nonexistent/script.js"
+    Then stderr contains a JSON error about file not found
+    And the exit code is non-zero
+
+  # --- Truncation ---
+
+  Scenario: Large result truncation with --max-size
+    Given a page is loaded at "https://example.com"
+    When I run "chrome-cli js exec --max-size 100 \"'x'.repeat(10000)\""
+    Then the JSON output contains a "truncated" field set to true
+    And the "result" field is shorter than 10000 characters
+
+  # --- Console Capture ---
+
+  Scenario: Console output captured during execution
+    Given a page is loaded at "https://example.com"
+    When I run "chrome-cli js exec 'console.log(\"hello\"); 42'"
+    Then the "result" field is 42
+    And the "console" field is an array
+    And the "console" array contains an entry with level "log" and text "hello"


### PR DESCRIPTION
## Summary

- Implement `js exec` command to execute arbitrary JavaScript in the browser page context via CDP `Runtime.evaluate` and `Runtime.callFunctionOn`
- Supports inline code, file input (`--file`), stdin (`-`), element context execution (`--uid`), promise handling (`--no-await`), timeout, result truncation (`--max-size`), and console capture
- Structured JSON output with `result`, `type`, `console`, and `truncated` fields; JavaScript exceptions returned as structured errors with stack traces on stderr

## Acceptance Criteria

From `.claude/specs/js-execution/requirements.md`:

- [ ] AC1: Execute a JavaScript expression — returns JSON with `result` and `type`
- [ ] AC2: Execute a JavaScript function — `() => { return 2 + 2; }` returns `4`
- [ ] AC3: Return all JavaScript value types — string, number, boolean, null, undefined, object, array
- [ ] AC4: Target a specific tab with `--tab`
- [ ] AC5: Await promise results (default behavior)
- [ ] AC6: Disable promise awaiting with `--no-await`
- [ ] AC7: Execution timeout with `--timeout`
- [ ] AC8: Execute JavaScript from a file with `--file`
- [ ] AC9: Read code from stdin with `-`
- [ ] AC10: Element context execution with `--uid`
- [ ] AC11: JavaScript exception handling (structured errors with stack)
- [ ] AC12: Reference error handling
- [ ] AC13: Large result truncation with `--max-size`
- [ ] AC14: UID not found error
- [ ] AC15: File not found error
- [ ] AC16: Console output capture

## Test Plan

- [ ] Unit tests: `JsExecResult` serialization, error helper constructors, code resolution logic
- [ ] BDD feature file: 16 Gherkin scenarios covering all acceptance criteria
- [ ] BDD step definitions: cucumber-rs steps for all scenarios
- [ ] Integration: `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, `cargo test --lib`

## Specs

- Requirements: `.claude/specs/js-execution/requirements.md`
- Design: `.claude/specs/js-execution/design.md`
- Tasks: `.claude/specs/js-execution/tasks.md`
- Feature: `.claude/specs/js-execution/feature.gherkin`

Closes #13