### PR TITLE
feat: add built-in examples subcommand (#29)

### DIFF
--- a/.claude/sdlc-state.json
+++ b/.claude/sdlc-state.json
@@ -1,10 +1,11 @@
 {
-  "currentStep": 0,
-  "currentIssue": null,
-  "currentBranch": "main",
-  "featureName": null,
-  "lastTransitionAt": "2026-02-14T17:35:15.522Z",
+  "currentStep": 4,
+  "currentIssue": 29,
+  "currentBranch": "29-built-in-examples-subcommand",
+  "featureName": "url-navigation",
+  "lastTransitionAt": "2026-02-14T18:09:26.334Z",
   "retries": {
-    "1": 1
-  }
+    "4": 2
+  },
+  "runnerPid": 57152
 }

--- a/.claude/sdlc-state.json
+++ b/.claude/sdlc-state.json
@@ -1,11 +1,10 @@
 {
-  "currentStep": 4,
+  "currentStep": 6,
+  "lastCompletedStep": 5,
   "currentIssue": 29,
   "currentBranch": "29-built-in-examples-subcommand",
-  "featureName": "url-navigation",
-  "lastTransitionAt": "2026-02-14T18:09:26.334Z",
-  "retries": {
-    "4": 2
-  },
-  "runnerPid": 57152
+  "featureName": "29-built-in-examples-subcommand",
+  "lastTransitionAt": "2026-02-14T19:05:33.835Z",
+  "retries": {},
+  "runnerPid": 77790
 }

--- a/.claude/specs/29-built-in-examples-subcommand/design.md
+++ b/.claude/specs/29-built-in-examples-subcommand/design.md
@@ -1,0 +1,307 @@
+# Design: Built-in Examples Subcommand
+
+**Issue**: #29
+**Date**: 2026-02-14
+**Status**: Draft
+**Author**: Claude (spec generation)
+
+---
+
+## Overview
+
+This feature adds a `chrome-cli examples` subcommand that prints usage examples for each command group. The command is a "meta" command (like `completions` and `man`) that requires no Chrome/CDP connection. It serves static, embedded example data in plain text or JSON format.
+
+The implementation follows the established patterns in the codebase: a new `Examples` variant in the `Command` enum, a new `examples.rs` module with static example data, and output formatting via the existing `OutputFormat` mechanism (--json, --pretty, --plain).
+
+---
+
+## Architecture
+
+### Component Diagram
+
+```
+CLI Input: chrome-cli examples [command] [--json|--pretty|--plain]
+    ↓
+┌──────────────────────────────┐
+│       CLI Layer (clap)       │ ← Parse args: optional command name, output format
+│  src/cli/mod.rs              │
+│  Command::Examples(args)     │
+└──────────┬───────────────────┘
+           ↓
+┌──────────────────────────────┐
+│    Examples Module            │ ← Static example data + formatting
+│  src/examples.rs             │
+│  execute_examples()          │
+└──────────┬───────────────────┘
+           ↓
+┌──────────────────────────────┐
+│    Output (stdout)           │ ← Plain text or JSON
+└──────────────────────────────┘
+```
+
+No CDP, Chrome, or session layers are involved.
+
+### Data Flow
+
+```
+1. User runs: chrome-cli examples [navigate] [--json]
+2. Clap parses into Command::Examples(ExamplesArgs { command: Option<String> })
+3. main.rs dispatches to examples::execute_examples(&global, &args)
+4. execute_examples() looks up example data:
+   a. If no command arg: return all command groups (summary view)
+   b. If command arg given: find matching group or return error
+5. Format output based on OutputFormat flags:
+   a. --plain (or default): human-readable text with # comment descriptions
+   b. --json: compact JSON
+   c. --pretty: pretty-printed JSON
+6. Print to stdout, exit 0
+```
+
+---
+
+## API / Interface Changes
+
+### New CLI Subcommand
+
+```
+chrome-cli examples [COMMAND] [--json|--pretty|--plain]
+```
+
+| Argument | Type | Required | Description |
+|----------|------|----------|-------------|
+| COMMAND | positional String | No | Command group name to show examples for |
+
+### New Enum Variant
+
+Added to `Command` enum in `src/cli/mod.rs`:
+
+```rust
+/// Show usage examples for commands
+#[command(
+    long_about = "Show usage examples for chrome-cli commands. Without arguments, lists all \
+        command groups with a brief description and one example each. With a command name, \
+        shows detailed examples for that specific command group.",
+    after_long_help = "\
+EXAMPLES:
+  # List all command groups with summary examples
+  chrome-cli examples
+
+  # Show detailed examples for the navigate command
+  chrome-cli examples navigate
+
+  # Get all examples as JSON (for programmatic use)
+  chrome-cli examples --json
+
+  # Pretty-printed JSON output
+  chrome-cli examples --pretty"
+)]
+Examples(ExamplesArgs),
+```
+
+### New Args Struct
+
+```rust
+#[derive(Args)]
+pub struct ExamplesArgs {
+    /// Command group to show examples for (e.g., navigate, tabs, page)
+    pub command: Option<String>,
+}
+```
+
+### Output Schemas
+
+**Summary mode (no command arg) — JSON:**
+
+```json
+[
+  {
+    "command": "connect",
+    "description": "Connect to or launch a Chrome instance",
+    "examples": [
+      {
+        "cmd": "chrome-cli connect",
+        "description": "Connect to Chrome on the default port"
+      },
+      {
+        "cmd": "chrome-cli connect --launch --headless",
+        "description": "Launch a new headless Chrome instance"
+      }
+    ]
+  }
+]
+```
+
+**Detail mode (with command arg) — JSON:**
+
+```json
+{
+  "command": "navigate",
+  "description": "URL navigation and history",
+  "examples": [
+    {
+      "cmd": "chrome-cli navigate https://example.com --wait-until load",
+      "description": "Navigate to a URL and wait for load",
+      "flags": ["--wait-until"]
+    },
+    {
+      "cmd": "chrome-cli navigate https://app.example.com --wait-until networkidle",
+      "description": "Navigate and wait for network idle (for SPAs)",
+      "flags": ["--wait-until"]
+    }
+  ]
+}
+```
+
+**Plain text (summary mode):**
+
+```
+connect — Connect to or launch a Chrome instance
+  chrome-cli connect
+
+tabs — Tab management (list, create, close, activate)
+  chrome-cli tabs list
+
+navigate — URL navigation and history
+  chrome-cli navigate https://example.com
+...
+```
+
+**Plain text (detail mode):**
+
+```
+navigate — URL navigation and history
+
+  # Navigate to a URL and wait for load
+  chrome-cli navigate https://example.com --wait-until load
+
+  # Navigate and wait for network idle (for SPAs)
+  chrome-cli navigate https://app.example.com --wait-until networkidle
+
+  # Go back in history
+  chrome-cli navigate back
+
+  # Reload without cache
+  chrome-cli navigate reload --ignore-cache
+```
+
+### Errors
+
+| Code | Condition |
+|------|-----------|
+| ExitCode::GeneralError (1) | Unknown command group name |
+
+---
+
+## Database / Storage Changes
+
+None. This is a purely static, in-memory feature.
+
+---
+
+## State Management
+
+None. The examples module contains only static data and pure formatting functions.
+
+---
+
+## Module Design
+
+### `src/examples.rs`
+
+```rust
+// 1. Output types (Serialize structs)
+#[derive(Serialize)]
+struct CommandGroupSummary {
+    command: String,
+    description: String,
+    examples: Vec<ExampleEntry>,
+}
+
+#[derive(Serialize)]
+struct ExampleEntry {
+    cmd: String,
+    description: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    flags: Option<Vec<String>>,
+}
+
+// 2. Static example data — one function returning Vec<CommandGroupSummary>
+fn all_examples() -> Vec<CommandGroupSummary> { ... }
+
+// 3. Output formatting (print_output, format_plain_summary, format_plain_detail)
+fn print_output(value: &impl Serialize, output: &OutputFormat) -> Result<(), AppError> { ... }
+fn format_plain_summary(groups: &[CommandGroupSummary]) -> String { ... }
+fn format_plain_detail(group: &CommandGroupSummary) -> String { ... }
+
+// 4. Dispatcher
+pub fn execute_examples(global: &GlobalOpts, args: &ExamplesArgs) -> Result<(), AppError> { ... }
+```
+
+### Dispatcher Pattern
+
+Follows the same synchronous pattern as `execute_completions` and `execute_man`:
+
+```rust
+// In main.rs run():
+Command::Examples(args) => examples::execute_examples(&global, args),
+```
+
+This is a sync function (no `async`), since no I/O is needed.
+
+---
+
+## Alternatives Considered
+
+| Option | Description | Pros | Cons | Decision |
+|--------|-------------|------|------|----------|
+| **A: Extract from clap help text** | Parse `after_long_help` at runtime | Single source of truth, no duplication | Fragile parsing, format limitations, can't add structured fields like `flags` | Rejected — brittle |
+| **B: Static embedded data** | Hardcode examples in `examples.rs` | Fast, simple, fully structured, easy to test | Duplication with clap help text | **Selected** — simplicity and structure |
+| **C: External data file** | Load examples from JSON/TOML at runtime | Easy to edit | Runtime file I/O, deployment complexity, single-binary principle violated | Rejected — adds file dependency |
+
+---
+
+## Security Considerations
+
+- [x] **No security impact**: Command prints static data, no user input affects behavior beyond command group lookup
+- [x] **Input Validation**: Command name is validated against known group names
+
+---
+
+## Performance Considerations
+
+- [x] **No CDP connection**: Sub-millisecond response time
+- [x] **Static data**: No I/O, no allocation beyond formatting
+
+---
+
+## Testing Strategy
+
+| Layer | Type | Coverage |
+|-------|------|----------|
+| Unit | #[test] in examples.rs | all_examples() returns expected groups, correct count |
+| Unit | #[test] in examples.rs | format_plain_summary(), format_plain_detail() produce expected output |
+| Integration | BDD (Gherkin) | End-to-end: run binary, verify output format and content |
+
+---
+
+## Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Examples become stale when commands change | Medium | Low | Test that example command names match Command enum variants |
+| Duplication between help text and examples | Low | Low | Accept as trade-off; examples module is the canonical structured source |
+
+---
+
+## Validation Checklist
+
+- [x] Architecture follows existing project patterns (per `structure.md`)
+- [x] All API/interface changes documented with schemas
+- [x] No database/storage changes needed
+- [x] No state management needed
+- [x] No UI components needed (CLI only)
+- [x] Security considerations addressed
+- [x] Performance impact analyzed
+- [x] Testing strategy defined
+- [x] Alternatives were considered and documented
+- [x] Risks identified with mitigations

--- a/.claude/specs/29-built-in-examples-subcommand/feature.gherkin
+++ b/.claude/specs/29-built-in-examples-subcommand/feature.gherkin
@@ -1,0 +1,107 @@
+# File: tests/features/examples.feature
+#
+# Generated from: .claude/specs/29-built-in-examples-subcommand/requirements.md
+# Issue: #29
+
+Feature: Built-in Examples Subcommand
+  As a developer or AI agent using chrome-cli
+  I want a dedicated examples subcommand that prints usage examples
+  So that I can discover working CLI invocations without parsing --help output
+
+  # --- Happy Path ---
+
+  Scenario: List all command groups with summary examples
+    Given chrome-cli is installed
+    When I run "chrome-cli examples"
+    Then the output lists every command group with a description and one example
+    And the output contains "connect"
+    And the output contains "tabs"
+    And the output contains "navigate"
+    And the output contains "page"
+    And the output contains "js"
+    And the output contains "console"
+    And the output contains "network"
+    And the output contains "interact"
+    And the output contains "form"
+    And the output contains "emulate"
+    And the output contains "perf"
+    And the output contains "dialog"
+    And the output contains "config"
+    And the exit code is 0
+
+  Scenario: Show detailed examples for a specific command group
+    Given chrome-cli is installed
+    When I run "chrome-cli examples navigate"
+    Then the output contains at least 3 examples
+    And each example includes a command string starting with "chrome-cli navigate"
+    And each example includes a description comment
+    And the exit code is 0
+
+  # --- Output Formats ---
+
+  Scenario: Plain text output is the default
+    Given chrome-cli is installed
+    When I run "chrome-cli examples"
+    Then the output is human-readable plain text
+    And the output does not start with "["
+    And the output does not start with "{"
+    And the exit code is 0
+
+  Scenario: JSON output for summary listing
+    Given chrome-cli is installed
+    When I run "chrome-cli examples --json"
+    Then the output is a valid JSON array
+    And each entry has a "command" field
+    And each entry has a "description" field
+    And each entry has an "examples" array
+    And each example has a "cmd" field
+    And each example has a "description" field
+    And the exit code is 0
+
+  Scenario: JSON output for a specific command group
+    Given chrome-cli is installed
+    When I run "chrome-cli examples navigate --json"
+    Then the output is a valid JSON object
+    And the "command" field is "navigate"
+    And the "examples" array has at least 3 entries
+    And the exit code is 0
+
+  Scenario: Pretty-printed JSON output
+    Given chrome-cli is installed
+    When I run "chrome-cli examples --pretty"
+    Then the output is a valid JSON array
+    And the output contains indentation (multi-line formatted)
+    And the exit code is 0
+
+  # --- Error Handling ---
+
+  Scenario: Error on unknown command group
+    Given chrome-cli is installed
+    When I run "chrome-cli examples nonexistent"
+    Then the exit code is 1
+    And stderr contains an error message about unknown command
+
+  # --- Coverage ---
+
+  Scenario Outline: Each command group has at least 3 examples
+    Given chrome-cli is installed
+    When I run "chrome-cli examples <group> --json"
+    Then the output is a valid JSON object
+    And the "examples" array has at least 3 entries
+    And the exit code is 0
+
+    Examples:
+      | group    |
+      | connect  |
+      | tabs     |
+      | navigate |
+      | page     |
+      | js       |
+      | console  |
+      | network  |
+      | interact |
+      | form     |
+      | emulate  |
+      | perf     |
+      | dialog   |
+      | config   |

--- a/.claude/specs/29-built-in-examples-subcommand/requirements.md
+++ b/.claude/specs/29-built-in-examples-subcommand/requirements.md
@@ -1,0 +1,230 @@
+# Requirements: Built-in Examples Subcommand
+
+**Issue**: #29
+**Date**: 2026-02-14
+**Status**: Draft
+**Author**: Claude (spec generation)
+
+---
+
+## User Story
+
+**As a** developer or AI agent using chrome-cli
+**I want** a dedicated `examples` subcommand that prints usage examples for each command group
+**So that** I can quickly discover working CLI invocations without parsing `--help` output or reading external documentation
+
+---
+
+## Background
+
+AI agents benefit from being able to query examples programmatically. The existing `--help` and `after_long_help` text in clap provides examples, but they are interleaved with flag descriptions and not easily machine-parseable. A dedicated `chrome-cli examples` command provides a focused, structured view of real usage patterns — in both plain text (human-readable) and JSON (machine-readable) formats.
+
+This aligns with the M6 milestone (Documentation & AI Discoverability) and the product principle of scriptability.
+
+---
+
+## Acceptance Criteria
+
+### AC1: List all command groups with summary examples
+
+**Given** chrome-cli is installed
+**When** I run `chrome-cli examples`
+**Then** the output lists every command group with a brief description and one representative example each
+**And** the exit code is 0
+
+**Example**:
+- Given: chrome-cli binary is on PATH
+- When: `chrome-cli examples`
+- Then: Output includes all command groups (connect, tabs, navigate, page, js, console, network, interact, form, emulate, perf, dialog, config) each with a one-line description and one example command
+
+### AC2: Show detailed examples for a specific command group
+
+**Given** chrome-cli is installed
+**When** I run `chrome-cli examples <COMMAND>` (e.g., `chrome-cli examples navigate`)
+**Then** the output shows 3–5 detailed examples for that command group
+**And** each example includes the command string and a description comment
+**And** the exit code is 0
+
+**Example**:
+- Given: chrome-cli binary is on PATH
+- When: `chrome-cli examples navigate`
+- Then: Output includes examples like "Navigate to a URL and wait for load" with `chrome-cli navigate https://example.com --wait-until load`
+
+### AC3: JSON output for summary listing
+
+**Given** chrome-cli is installed
+**When** I run `chrome-cli examples --json`
+**Then** the output is a valid JSON array of objects with `command`, `description`, and `examples` fields
+**And** each example object contains `cmd` and `description` fields
+**And** the exit code is 0
+
+### AC4: JSON output for a specific command group
+
+**Given** chrome-cli is installed
+**When** I run `chrome-cli examples navigate --json`
+**Then** the output is a valid JSON object with `command`, `description`, and `examples` fields
+**And** each example includes `cmd`, `description`, and optional `flags` fields
+**And** the exit code is 0
+
+### AC5: Error on unknown command group
+
+**Given** chrome-cli is installed
+**When** I run `chrome-cli examples nonexistent`
+**Then** the output is an error message indicating the command group is not recognized
+**And** the exit code is non-zero
+
+### AC6: All command groups have examples
+
+**Given** chrome-cli is installed
+**When** I run `chrome-cli examples --json`
+**Then** the output contains entries for all command groups: connect, tabs, navigate, page, js, console, network, interact, form, emulate, perf, dialog, config
+**And** each command group has at least 3 examples
+
+### AC7: Plain text output is the default
+
+**Given** chrome-cli is installed
+**When** I run `chrome-cli examples` without any output flags
+**Then** the output is human-readable plain text (not JSON)
+**And** examples are formatted with comment-style descriptions (# prefix)
+
+### AC8: Pretty-printed JSON output
+
+**Given** chrome-cli is installed
+**When** I run `chrome-cli examples --pretty`
+**Then** the output is a pretty-printed (indented) JSON array
+**And** the exit code is 0
+
+### Generated Gherkin Preview
+
+```gherkin
+Feature: Built-in Examples Subcommand
+  As a developer or AI agent
+  I want a dedicated examples subcommand
+  So that I can discover working CLI invocations without parsing --help output
+
+  Scenario: List all command groups with summary examples
+    Given chrome-cli is installed
+    When I run "chrome-cli examples"
+    Then the output lists every command group with a description and example
+    And the exit code is 0
+
+  Scenario: Show detailed examples for a specific command group
+    Given chrome-cli is installed
+    When I run "chrome-cli examples navigate"
+    Then the output shows 3-5 detailed examples for "navigate"
+    And each example includes a command and description
+    And the exit code is 0
+
+  Scenario: JSON output for summary listing
+    Given chrome-cli is installed
+    When I run "chrome-cli examples --json"
+    Then the output is a valid JSON array
+    And each entry has "command", "description", and "examples" fields
+
+  Scenario: Error on unknown command group
+    Given chrome-cli is installed
+    When I run "chrome-cli examples nonexistent"
+    Then the output contains an error message
+    And the exit code is non-zero
+```
+
+---
+
+## Functional Requirements
+
+| ID | Requirement | Priority | Notes |
+|----|-------------|----------|-------|
+| FR1 | `chrome-cli examples` lists all command groups with one example each | Must | Default plain text output |
+| FR2 | `chrome-cli examples <COMMAND>` shows detailed examples for one group | Must | 3–5 examples per group |
+| FR3 | `--json` flag produces structured JSON output | Must | Follows existing OutputFormat pattern |
+| FR4 | `--pretty` flag produces pretty-printed JSON | Must | Follows existing OutputFormat pattern |
+| FR5 | `--plain` flag forces plain text output | Must | Follows existing OutputFormat pattern |
+| FR6 | Every command group (connect, tabs, navigate, page, js, console, network, interact, form, emulate, perf, dialog, config) has examples | Must | At least 3 examples each |
+| FR7 | Examples are syntactically valid chrome-cli commands | Should | Verified at test time |
+| FR8 | Error on unknown command group names | Must | Non-zero exit code |
+
+---
+
+## Non-Functional Requirements
+
+| Aspect | Requirement |
+|--------|-------------|
+| **Performance** | Command should respond in < 10ms (no Chrome connection needed) |
+| **Security** | No security implications — purely informational, no network/CDP calls |
+| **Platforms** | Same as chrome-cli: macOS, Linux, Windows |
+| **Reliability** | Static data, no external dependencies — always works |
+
+---
+
+## Data Requirements
+
+### Input Data
+
+| Field | Type | Validation | Required |
+|-------|------|------------|----------|
+| command | String (positional arg) | Must match a known command group name | No |
+
+### Output Data (JSON mode)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| command | String | Command group name (e.g., "navigate") |
+| description | String | Brief description of the command group |
+| examples | Array | List of example objects |
+| examples[].cmd | String | Full command string |
+| examples[].description | String | What the example demonstrates |
+| examples[].flags | Array<String> | Optional: relevant flags used |
+
+---
+
+## Dependencies
+
+### Internal Dependencies
+- [x] All CLI command groups implemented (connect, tabs, navigate, page, js, console, network, interact, form, emulate, perf, dialog, config)
+- [x] `OutputFormat` global flags (--json, --pretty, --plain) already exist
+
+### External Dependencies
+- None
+
+### Blocked By
+- None (all command groups already exist)
+
+---
+
+## Out of Scope
+
+- Interactive / REPL mode for exploring examples
+- Workflow/recipe examples that chain multiple commands (future enhancement)
+- Generating examples from test fixtures or golden files (future enhancement)
+- Markdown or HTML output formats
+- Man page generation for examples (covered by `chrome-cli man`)
+
+---
+
+## Success Metrics
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| Command group coverage | 100% of groups have examples | Count groups in JSON output |
+| Examples per group | ≥ 3 per group | Count examples in JSON output |
+| Response time | < 10ms | No CDP connection required |
+
+---
+
+## Open Questions
+
+- None — requirements are clear from the issue.
+
+---
+
+## Validation Checklist
+
+- [x] User story follows "As a / I want / So that" format
+- [x] All acceptance criteria use Given/When/Then format
+- [x] No implementation details in requirements
+- [x] All criteria are testable and unambiguous
+- [x] Success metrics are measurable
+- [x] Edge cases and error states are specified
+- [x] Dependencies are identified
+- [x] Out of scope is defined
+- [x] Open questions are documented (or resolved)

--- a/.claude/specs/29-built-in-examples-subcommand/tasks.md
+++ b/.claude/specs/29-built-in-examples-subcommand/tasks.md
@@ -1,0 +1,158 @@
+# Tasks: Built-in Examples Subcommand
+
+**Issue**: #29
+**Date**: 2026-02-14
+**Status**: Planning
+**Author**: Claude (spec generation)
+
+---
+
+## Summary
+
+| Phase | Tasks | Status |
+|-------|-------|--------|
+| Setup | 2 | [ ] |
+| Backend | 2 | [ ] |
+| Integration | 1 | [ ] |
+| Testing | 2 | [ ] |
+| **Total** | **7** | |
+
+---
+
+## Phase 1: Setup
+
+### T001: Add ExamplesArgs struct and Command::Examples variant
+
+**File(s)**: `src/cli/mod.rs`
+**Type**: Modify
+**Depends**: None
+**Acceptance**:
+- [ ] `ExamplesArgs` struct with optional `command: Option<String>` field
+- [ ] `Command::Examples(ExamplesArgs)` variant added to `Command` enum
+- [ ] Help text includes `long_about` and `after_long_help` with examples
+- [ ] `ExamplesArgs` imported in `src/main.rs` use statement
+- [ ] `cargo check` passes
+
+**Notes**: Follow the pattern of `ManArgs` — a simple struct with one optional positional arg. Add the variant between `Man` and `Completions` (or at the end) in the enum.
+
+### T002: Define output types for examples data
+
+**File(s)**: `src/examples.rs` (create)
+**Type**: Create
+**Depends**: None
+**Acceptance**:
+- [ ] `CommandGroupSummary` struct with `command: String`, `description: String`, `examples: Vec<ExampleEntry>`
+- [ ] `ExampleEntry` struct with `cmd: String`, `description: String`, `flags: Option<Vec<String>>`
+- [ ] Both structs derive `Serialize`
+- [ ] `flags` field uses `#[serde(skip_serializing_if = "Option::is_none")]`
+- [ ] `cargo check` passes
+
+---
+
+## Phase 2: Backend Implementation
+
+### T003: Implement static example data
+
+**File(s)**: `src/examples.rs`
+**Type**: Modify
+**Depends**: T002
+**Acceptance**:
+- [ ] `fn all_examples() -> Vec<CommandGroupSummary>` returns data for all 13 command groups: connect, tabs, navigate, page, dom, js, console, network, interact, form, emulate, perf, dialog, config
+- [ ] Each command group has 3–5 examples
+- [ ] Each example `cmd` is a syntactically valid chrome-cli invocation
+- [ ] Examples cover common use cases per the existing `after_long_help` text in cli/mod.rs
+- [ ] `flags` field populated where relevant
+
+### T004: Implement execute_examples dispatcher and formatting
+
+**File(s)**: `src/examples.rs`
+**Type**: Modify
+**Depends**: T001, T003
+**Acceptance**:
+- [ ] `pub fn execute_examples(global: &GlobalOpts, args: &ExamplesArgs) -> Result<(), AppError>` implemented
+- [ ] Without command arg: prints all groups (summary view)
+- [ ] With command arg: prints detailed examples for that group
+- [ ] Unknown command arg returns `AppError` with `ExitCode::GeneralError`
+- [ ] Plain text output: uses `# description` comment style, indented commands
+- [ ] JSON output: compact JSON via `serde_json::to_string`
+- [ ] Pretty output: indented JSON via `serde_json::to_string_pretty`
+- [ ] Default (no output flags): plain text
+- [ ] `print_output` helper follows `tabs.rs` pattern
+
+---
+
+## Phase 3: Integration
+
+### T005: Wire examples command into main dispatcher
+
+**File(s)**: `src/main.rs`
+**Type**: Modify
+**Depends**: T004
+**Acceptance**:
+- [ ] `mod examples;` added to module declarations
+- [ ] `ExamplesArgs` imported from `cli` module
+- [ ] `Command::Examples(args) => examples::execute_examples(&global, args)` added to match in `run()`
+- [ ] No `async` — this is a sync call (same as `execute_completions`, `execute_man`)
+- [ ] `cargo build` succeeds
+- [ ] Running `chrome-cli examples` prints expected output
+- [ ] Running `chrome-cli examples navigate` prints navigate examples
+- [ ] Running `chrome-cli examples --json` prints valid JSON
+- [ ] Running `chrome-cli examples nonexistent` exits non-zero with error
+
+---
+
+## Phase 4: Testing
+
+### T006: Create BDD feature file for examples command
+
+**File(s)**: `tests/features/examples.feature`
+**Type**: Create
+**Depends**: T005
+**Acceptance**:
+- [ ] All 8 acceptance criteria from requirements.md have corresponding scenarios
+- [ ] Uses Given/When/Then format
+- [ ] Includes error handling scenarios (unknown command)
+- [ ] Feature file is valid Gherkin syntax
+- [ ] Includes data-driven scenarios for per-group coverage
+
+### T007: Add unit tests for examples module
+
+**File(s)**: `src/examples.rs` (inline `#[cfg(test)]` module)
+**Type**: Modify
+**Depends**: T003, T004
+**Acceptance**:
+- [ ] Test: `all_examples()` returns expected number of command groups (13+)
+- [ ] Test: each group has at least 3 examples
+- [ ] Test: no empty `cmd` or `description` fields
+- [ ] Test: `execute_examples` with `None` command succeeds
+- [ ] Test: `execute_examples` with valid command name succeeds
+- [ ] Test: `execute_examples` with unknown command returns error
+- [ ] Test: plain text formatting produces expected structure
+- [ ] `cargo test` passes
+
+---
+
+## Dependency Graph
+
+```
+T001 (CLI args) ──┐
+                  ├──▶ T004 (dispatcher) ──▶ T005 (wire into main) ──▶ T006 (BDD)
+T002 (types) ─┬──┘
+              │
+              └──▶ T003 (data) ──▶ T004
+                                    │
+                                    └──▶ T007 (unit tests)
+```
+
+---
+
+## Validation Checklist
+
+- [x] Each task has single responsibility
+- [x] Dependencies are correctly mapped
+- [x] Tasks can be completed independently (given dependencies)
+- [x] Acceptance criteria are verifiable
+- [x] File paths reference actual project structure (per `structure.md`)
+- [x] Test tasks are included for each layer
+- [x] No circular dependencies
+- [x] Tasks are in logical execution order

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -464,6 +464,27 @@ EXAMPLES:
     )]
     Completions(CompletionsArgs),
 
+    /// Show usage examples for commands
+    #[command(
+        long_about = "Show usage examples for chrome-cli commands. Without arguments, lists all \
+            command groups with a brief description and one example each. With a command name, \
+            shows detailed examples for that specific command group.",
+        after_long_help = "\
+EXAMPLES:
+  # List all command groups with summary examples
+  chrome-cli examples
+
+  # Show detailed examples for the navigate command
+  chrome-cli examples navigate
+
+  # Get all examples as JSON (for programmatic use)
+  chrome-cli examples --json
+
+  # Pretty-printed JSON output
+  chrome-cli examples --pretty"
+    )]
+    Examples(ExamplesArgs),
+
     /// Display man pages for chrome-cli commands
     #[command(
         long_about = "Display man pages for chrome-cli commands. Without arguments, displays \
@@ -2049,5 +2070,12 @@ pub struct CompletionsArgs {
 #[derive(Args)]
 pub struct ManArgs {
     /// Subcommand to display man page for (omit for top-level)
+    pub command: Option<String>,
+}
+
+/// Arguments for the `examples` subcommand.
+#[derive(Args)]
+pub struct ExamplesArgs {
+    /// Command group to show examples for (e.g., navigate, tabs, page)
     pub command: Option<String>,
 }

--- a/src/examples.rs
+++ b/src/examples.rs
@@ -1,0 +1,643 @@
+use std::fmt::Write;
+
+use serde::Serialize;
+
+use chrome_cli::error::{AppError, ExitCode};
+
+use crate::cli::{ExamplesArgs, GlobalOpts};
+
+// =============================================================================
+// Output types
+// =============================================================================
+
+#[derive(Serialize)]
+struct CommandGroupSummary {
+    command: String,
+    description: String,
+    examples: Vec<ExampleEntry>,
+}
+
+#[derive(Serialize)]
+struct ExampleEntry {
+    cmd: String,
+    description: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    flags: Option<Vec<String>>,
+}
+
+// =============================================================================
+// Static example data
+// =============================================================================
+
+#[allow(clippy::too_many_lines)]
+fn all_examples() -> Vec<CommandGroupSummary> {
+    vec![
+        CommandGroupSummary {
+            command: "connect".into(),
+            description: "Connect to or launch a Chrome instance".into(),
+            examples: vec![
+                ExampleEntry {
+                    cmd: "chrome-cli connect".into(),
+                    description: "Connect to Chrome on the default port (9222)".into(),
+                    flags: None,
+                },
+                ExampleEntry {
+                    cmd: "chrome-cli connect --launch --headless".into(),
+                    description: "Launch a new headless Chrome instance".into(),
+                    flags: Some(vec!["--launch".into(), "--headless".into()]),
+                },
+                ExampleEntry {
+                    cmd: "chrome-cli connect --port 9333".into(),
+                    description: "Connect to Chrome on a specific port".into(),
+                    flags: Some(vec!["--port".into()]),
+                },
+                ExampleEntry {
+                    cmd: "chrome-cli connect --status".into(),
+                    description: "Check current connection status".into(),
+                    flags: Some(vec!["--status".into()]),
+                },
+                ExampleEntry {
+                    cmd: "chrome-cli connect --disconnect".into(),
+                    description: "Disconnect and remove the session file".into(),
+                    flags: Some(vec!["--disconnect".into()]),
+                },
+            ],
+        },
+        CommandGroupSummary {
+            command: "tabs".into(),
+            description: "Tab management (list, create, close, activate)".into(),
+            examples: vec![
+                ExampleEntry {
+                    cmd: "chrome-cli tabs list".into(),
+                    description: "List all open tabs".into(),
+                    flags: None,
+                },
+                ExampleEntry {
+                    cmd: "chrome-cli tabs create https://example.com".into(),
+                    description: "Open a new tab with a URL".into(),
+                    flags: None,
+                },
+                ExampleEntry {
+                    cmd: "chrome-cli tabs close ABC123".into(),
+                    description: "Close a tab by its ID".into(),
+                    flags: None,
+                },
+                ExampleEntry {
+                    cmd: "chrome-cli tabs activate ABC123".into(),
+                    description: "Activate (focus) a tab by its ID".into(),
+                    flags: None,
+                },
+                ExampleEntry {
+                    cmd: "chrome-cli tabs list --all".into(),
+                    description: "List all tabs including internal Chrome pages".into(),
+                    flags: Some(vec!["--all".into()]),
+                },
+            ],
+        },
+        CommandGroupSummary {
+            command: "navigate".into(),
+            description: "URL navigation and history".into(),
+            examples: vec![
+                ExampleEntry {
+                    cmd: "chrome-cli navigate https://example.com".into(),
+                    description: "Navigate to a URL and wait for load".into(),
+                    flags: None,
+                },
+                ExampleEntry {
+                    cmd: "chrome-cli navigate https://app.example.com --wait-until networkidle"
+                        .into(),
+                    description: "Navigate and wait for network idle (for SPAs)".into(),
+                    flags: Some(vec!["--wait-until".into()]),
+                },
+                ExampleEntry {
+                    cmd: "chrome-cli navigate back".into(),
+                    description: "Go back in browser history".into(),
+                    flags: None,
+                },
+                ExampleEntry {
+                    cmd: "chrome-cli navigate reload --ignore-cache".into(),
+                    description: "Reload the page without cache".into(),
+                    flags: Some(vec!["--ignore-cache".into()]),
+                },
+            ],
+        },
+        CommandGroupSummary {
+            command: "page".into(),
+            description: "Page inspection (screenshot, text, accessibility tree, find)".into(),
+            examples: vec![
+                ExampleEntry {
+                    cmd: "chrome-cli page text".into(),
+                    description: "Extract all visible text from the page".into(),
+                    flags: None,
+                },
+                ExampleEntry {
+                    cmd: "chrome-cli page snapshot".into(),
+                    description: "Capture the accessibility tree with element UIDs".into(),
+                    flags: None,
+                },
+                ExampleEntry {
+                    cmd: "chrome-cli page screenshot --full-page --file page.png".into(),
+                    description: "Take a full-page screenshot".into(),
+                    flags: Some(vec!["--full-page".into(), "--file".into()]),
+                },
+                ExampleEntry {
+                    cmd: "chrome-cli page find \"Sign in\"".into(),
+                    description: "Find elements by text".into(),
+                    flags: None,
+                },
+                ExampleEntry {
+                    cmd: "chrome-cli page resize 1280x720".into(),
+                    description: "Resize the viewport to specific dimensions".into(),
+                    flags: None,
+                },
+            ],
+        },
+        CommandGroupSummary {
+            command: "dom".into(),
+            description: "DOM inspection and manipulation (not yet implemented)".into(),
+            examples: vec![
+                ExampleEntry {
+                    cmd: "chrome-cli page snapshot".into(),
+                    description: "Use page snapshot as an alternative to DOM queries".into(),
+                    flags: None,
+                },
+                ExampleEntry {
+                    cmd: "chrome-cli js exec \"document.querySelector('#myId').textContent\"".into(),
+                    description: "Use js exec to query DOM elements".into(),
+                    flags: None,
+                },
+                ExampleEntry {
+                    cmd: "chrome-cli js exec \"document.querySelectorAll('a').length\"".into(),
+                    description: "Count elements matching a selector".into(),
+                    flags: None,
+                },
+            ],
+        },
+        CommandGroupSummary {
+            command: "js".into(),
+            description: "JavaScript execution in page context".into(),
+            examples: vec![
+                ExampleEntry {
+                    cmd: "chrome-cli js exec \"document.title\"".into(),
+                    description: "Get the page title".into(),
+                    flags: None,
+                },
+                ExampleEntry {
+                    cmd: "chrome-cli js exec --file script.js".into(),
+                    description: "Execute a JavaScript file".into(),
+                    flags: Some(vec!["--file".into()]),
+                },
+                ExampleEntry {
+                    cmd: "chrome-cli js exec --uid s3 \"(el) => el.textContent\"".into(),
+                    description: "Run code on a specific element by UID".into(),
+                    flags: Some(vec!["--uid".into()]),
+                },
+                ExampleEntry {
+                    cmd: "echo 'document.URL' | chrome-cli js exec -".into(),
+                    description: "Read JavaScript from stdin".into(),
+                    flags: None,
+                },
+            ],
+        },
+        CommandGroupSummary {
+            command: "console".into(),
+            description: "Console message reading and monitoring".into(),
+            examples: vec![
+                ExampleEntry {
+                    cmd: "chrome-cli console read".into(),
+                    description: "Read recent console messages".into(),
+                    flags: None,
+                },
+                ExampleEntry {
+                    cmd: "chrome-cli console read --errors-only".into(),
+                    description: "Show only error messages".into(),
+                    flags: Some(vec!["--errors-only".into()]),
+                },
+                ExampleEntry {
+                    cmd: "chrome-cli console follow".into(),
+                    description: "Stream console messages in real time".into(),
+                    flags: None,
+                },
+                ExampleEntry {
+                    cmd: "chrome-cli console follow --errors-only --timeout 10000".into(),
+                    description: "Stream errors for 10 seconds".into(),
+                    flags: Some(vec!["--errors-only".into(), "--timeout".into()]),
+                },
+            ],
+        },
+        CommandGroupSummary {
+            command: "network".into(),
+            description: "Network request monitoring and interception".into(),
+            examples: vec![
+                ExampleEntry {
+                    cmd: "chrome-cli network list".into(),
+                    description: "List recent network requests".into(),
+                    flags: None,
+                },
+                ExampleEntry {
+                    cmd: "chrome-cli network list --type xhr,fetch".into(),
+                    description: "Filter requests by resource type".into(),
+                    flags: Some(vec!["--type".into()]),
+                },
+                ExampleEntry {
+                    cmd: "chrome-cli network get 42".into(),
+                    description: "Get details of a specific request by ID".into(),
+                    flags: None,
+                },
+                ExampleEntry {
+                    cmd: "chrome-cli network follow --url api.example.com".into(),
+                    description: "Stream network requests matching a URL pattern".into(),
+                    flags: Some(vec!["--url".into()]),
+                },
+            ],
+        },
+        CommandGroupSummary {
+            command: "interact".into(),
+            description: "Mouse, keyboard, and scroll interactions".into(),
+            examples: vec![
+                ExampleEntry {
+                    cmd: "chrome-cli interact click s5".into(),
+                    description: "Click an element by UID".into(),
+                    flags: None,
+                },
+                ExampleEntry {
+                    cmd: "chrome-cli interact click css:#submit-btn".into(),
+                    description: "Click an element by CSS selector".into(),
+                    flags: None,
+                },
+                ExampleEntry {
+                    cmd: "chrome-cli interact type \"Hello, world!\"".into(),
+                    description: "Type text into the focused element".into(),
+                    flags: None,
+                },
+                ExampleEntry {
+                    cmd: "chrome-cli interact key Control+A".into(),
+                    description: "Press a key combination".into(),
+                    flags: None,
+                },
+                ExampleEntry {
+                    cmd: "chrome-cli interact scroll --to-bottom".into(),
+                    description: "Scroll to the bottom of the page".into(),
+                    flags: Some(vec!["--to-bottom".into()]),
+                },
+            ],
+        },
+        CommandGroupSummary {
+            command: "form".into(),
+            description: "Form input and submission".into(),
+            examples: vec![
+                ExampleEntry {
+                    cmd: "chrome-cli form fill s5 \"hello@example.com\"".into(),
+                    description: "Fill a form field by UID".into(),
+                    flags: None,
+                },
+                ExampleEntry {
+                    cmd: "chrome-cli form fill css:#email \"user@example.com\"".into(),
+                    description: "Fill a form field by CSS selector".into(),
+                    flags: None,
+                },
+                ExampleEntry {
+                    cmd: "chrome-cli form clear s5".into(),
+                    description: "Clear a form field".into(),
+                    flags: None,
+                },
+                ExampleEntry {
+                    cmd: "chrome-cli form upload s10 ./photo.jpg".into(),
+                    description: "Upload a file to a file input element".into(),
+                    flags: None,
+                },
+            ],
+        },
+        CommandGroupSummary {
+            command: "emulate".into(),
+            description: "Device and network emulation".into(),
+            examples: vec![
+                ExampleEntry {
+                    cmd: "chrome-cli emulate set --viewport 375x667 --device-scale 2 --mobile"
+                        .into(),
+                    description: "Emulate a mobile device".into(),
+                    flags: Some(vec![
+                        "--viewport".into(),
+                        "--device-scale".into(),
+                        "--mobile".into(),
+                    ]),
+                },
+                ExampleEntry {
+                    cmd: "chrome-cli emulate set --network 3g".into(),
+                    description: "Simulate slow 3G network".into(),
+                    flags: Some(vec!["--network".into()]),
+                },
+                ExampleEntry {
+                    cmd: "chrome-cli emulate set --color-scheme dark".into(),
+                    description: "Force dark mode".into(),
+                    flags: Some(vec!["--color-scheme".into()]),
+                },
+                ExampleEntry {
+                    cmd: "chrome-cli emulate status".into(),
+                    description: "Check current emulation settings".into(),
+                    flags: None,
+                },
+                ExampleEntry {
+                    cmd: "chrome-cli emulate reset".into(),
+                    description: "Clear all emulation overrides".into(),
+                    flags: None,
+                },
+            ],
+        },
+        CommandGroupSummary {
+            command: "perf".into(),
+            description: "Performance tracing and metrics".into(),
+            examples: vec![
+                ExampleEntry {
+                    cmd: "chrome-cli perf vitals".into(),
+                    description: "Quick Core Web Vitals measurement".into(),
+                    flags: None,
+                },
+                ExampleEntry {
+                    cmd: "chrome-cli perf start --reload".into(),
+                    description: "Start a trace with page reload".into(),
+                    flags: Some(vec!["--reload".into()]),
+                },
+                ExampleEntry {
+                    cmd: "chrome-cli perf stop".into(),
+                    description: "Stop the active trace and collect data".into(),
+                    flags: None,
+                },
+                ExampleEntry {
+                    cmd: "chrome-cli perf analyze RenderBlocking --trace-file trace.json".into(),
+                    description: "Analyze render-blocking resources from a trace".into(),
+                    flags: Some(vec!["--trace-file".into()]),
+                },
+            ],
+        },
+        CommandGroupSummary {
+            command: "dialog".into(),
+            description: "Browser dialog handling (alert, confirm, prompt, beforeunload)".into(),
+            examples: vec![
+                ExampleEntry {
+                    cmd: "chrome-cli dialog info".into(),
+                    description: "Check if a dialog is currently open".into(),
+                    flags: None,
+                },
+                ExampleEntry {
+                    cmd: "chrome-cli dialog handle accept".into(),
+                    description: "Accept an alert or confirm dialog".into(),
+                    flags: None,
+                },
+                ExampleEntry {
+                    cmd: "chrome-cli dialog handle dismiss".into(),
+                    description: "Dismiss a dialog".into(),
+                    flags: None,
+                },
+                ExampleEntry {
+                    cmd: "chrome-cli dialog handle accept --text \"my input\"".into(),
+                    description: "Accept a prompt dialog with text".into(),
+                    flags: Some(vec!["--text".into()]),
+                },
+            ],
+        },
+        CommandGroupSummary {
+            command: "config".into(),
+            description: "Configuration file management (show, init, path)".into(),
+            examples: vec![
+                ExampleEntry {
+                    cmd: "chrome-cli config show".into(),
+                    description: "Show the resolved configuration from all sources".into(),
+                    flags: None,
+                },
+                ExampleEntry {
+                    cmd: "chrome-cli config init".into(),
+                    description: "Create a default config file".into(),
+                    flags: None,
+                },
+                ExampleEntry {
+                    cmd: "chrome-cli config init --path ./my-config.toml".into(),
+                    description: "Create a config at a custom path".into(),
+                    flags: Some(vec!["--path".into()]),
+                },
+                ExampleEntry {
+                    cmd: "chrome-cli config path".into(),
+                    description: "Show the active config file path".into(),
+                    flags: None,
+                },
+            ],
+        },
+    ]
+}
+
+// =============================================================================
+// Output formatting
+// =============================================================================
+
+fn print_output(
+    value: &impl Serialize,
+    output: &crate::cli::OutputFormat,
+) -> Result<(), AppError> {
+    let json = if output.pretty {
+        serde_json::to_string_pretty(value)
+    } else {
+        serde_json::to_string(value)
+    };
+    let json = json.map_err(|e| AppError {
+        message: format!("serialization error: {e}"),
+        code: ExitCode::GeneralError,
+    })?;
+    println!("{json}");
+    Ok(())
+}
+
+fn format_plain_summary(groups: &[CommandGroupSummary]) -> String {
+    let mut out = String::new();
+    for (i, group) in groups.iter().enumerate() {
+        if i > 0 {
+            out.push('\n');
+        }
+        let _ = writeln!(out, "{} \u{2014} {}", group.command, group.description);
+        if let Some(first) = group.examples.first() {
+            let _ = writeln!(out, "  {}", first.cmd);
+        }
+    }
+    out
+}
+
+fn format_plain_detail(group: &CommandGroupSummary) -> String {
+    let mut out = String::new();
+    let _ = writeln!(out, "{} \u{2014} {}", group.command, group.description);
+    for example in &group.examples {
+        out.push('\n');
+        let _ = writeln!(out, "  # {}", example.description);
+        let _ = writeln!(out, "  {}", example.cmd);
+    }
+    out
+}
+
+// =============================================================================
+// Dispatcher
+// =============================================================================
+
+pub fn execute_examples(global: &GlobalOpts, args: &ExamplesArgs) -> Result<(), AppError> {
+    let groups = all_examples();
+    let is_plain = !global.output.json && !global.output.pretty;
+
+    match &args.command {
+        None => {
+            if is_plain {
+                print!("{}", format_plain_summary(&groups));
+            } else {
+                print_output(&groups, &global.output)?;
+            }
+        }
+        Some(name) => {
+            let group = groups.into_iter().find(|g| g.command == *name);
+            match group {
+                Some(g) => {
+                    if is_plain {
+                        print!("{}", format_plain_detail(&g));
+                    } else {
+                        print_output(&g, &global.output)?;
+                    }
+                }
+                None => {
+                    return Err(AppError {
+                        message: format!(
+                            "Unknown command group: '{name}'. Available: connect, tabs, navigate, \
+                             page, dom, js, console, network, interact, form, emulate, perf, \
+                             dialog, config"
+                        ),
+                        code: ExitCode::GeneralError,
+                    });
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn all_examples_returns_expected_groups() {
+        let groups = all_examples();
+        let names: Vec<&str> = groups.iter().map(|g| g.command.as_str()).collect();
+        assert!(names.contains(&"connect"));
+        assert!(names.contains(&"tabs"));
+        assert!(names.contains(&"navigate"));
+        assert!(names.contains(&"page"));
+        assert!(names.contains(&"dom"));
+        assert!(names.contains(&"js"));
+        assert!(names.contains(&"console"));
+        assert!(names.contains(&"network"));
+        assert!(names.contains(&"interact"));
+        assert!(names.contains(&"form"));
+        assert!(names.contains(&"emulate"));
+        assert!(names.contains(&"perf"));
+        assert!(names.contains(&"dialog"));
+        assert!(names.contains(&"config"));
+    }
+
+    #[test]
+    fn each_group_has_at_least_3_examples() {
+        for group in all_examples() {
+            assert!(
+                group.examples.len() >= 3,
+                "Group '{}' has only {} examples, expected at least 3",
+                group.command,
+                group.examples.len()
+            );
+        }
+    }
+
+    #[test]
+    fn no_empty_fields() {
+        for group in all_examples() {
+            assert!(!group.command.is_empty());
+            assert!(!group.description.is_empty());
+            for example in &group.examples {
+                assert!(
+                    !example.cmd.is_empty(),
+                    "Empty cmd in group '{}'",
+                    group.command
+                );
+                assert!(
+                    !example.description.is_empty(),
+                    "Empty description in group '{}'",
+                    group.command
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn plain_summary_contains_all_groups() {
+        let groups = all_examples();
+        let output = format_plain_summary(&groups);
+        for group in &groups {
+            assert!(
+                output.contains(&group.command),
+                "Summary missing group '{}'",
+                group.command
+            );
+        }
+    }
+
+    #[test]
+    fn plain_summary_does_not_start_with_json() {
+        let groups = all_examples();
+        let output = format_plain_summary(&groups);
+        assert!(!output.starts_with('['));
+        assert!(!output.starts_with('{'));
+    }
+
+    #[test]
+    fn plain_detail_contains_descriptions_and_commands() {
+        let groups = all_examples();
+        let group = groups.iter().find(|g| g.command == "navigate").unwrap();
+        let output = format_plain_detail(group);
+        assert!(output.contains("navigate"));
+        for example in &group.examples {
+            assert!(
+                output.contains(&example.cmd),
+                "Detail missing cmd: {}",
+                example.cmd
+            );
+            assert!(
+                output.contains(&example.description),
+                "Detail missing description: {}",
+                example.description
+            );
+        }
+    }
+
+    #[test]
+    fn execute_examples_unknown_command_returns_error() {
+        let global = GlobalOpts {
+            port: None,
+            host: "127.0.0.1".into(),
+            ws_url: None,
+            timeout: None,
+            tab: None,
+            auto_dismiss_dialogs: false,
+            config: None,
+            output: crate::cli::OutputFormat {
+                json: false,
+                pretty: false,
+                plain: false,
+            },
+        };
+        let args = ExamplesArgs {
+            command: Some("nonexistent".into()),
+        };
+        let result = execute_examples(&global, &args);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.message.contains("Unknown command group"));
+        assert!(err.message.contains("nonexistent"));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod cli;
 mod console;
 mod dialog;
 mod emulate;
+mod examples;
 mod form;
 mod interact;
 mod js;
@@ -64,6 +65,7 @@ async fn run(cli: &Cli) -> Result<(), AppError> {
         Command::Emulate(args) => emulate::execute_emulate(&global, args).await,
         Command::Perf(args) => perf::execute_perf(&global, args).await,
         Command::Dialog(args) => dialog::execute_dialog(&global, args).await,
+        Command::Examples(args) => examples::execute_examples(&global, args),
         Command::Completions(args) => execute_completions(args),
         Command::Man(args) => execute_man(args),
     }

--- a/tests/features/examples.feature
+++ b/tests/features/examples.feature
@@ -11,84 +11,80 @@ Feature: Built-in Examples Subcommand
   # --- Happy Path ---
 
   Scenario: List all command groups with summary examples
-    Given chrome-cli is installed
+    Given the chrome-cli binary is available
     When I run "chrome-cli examples"
-    Then the output lists every command group with a description and one example
-    And the output contains "connect"
-    And the output contains "tabs"
-    And the output contains "navigate"
-    And the output contains "page"
-    And the output contains "js"
-    And the output contains "console"
-    And the output contains "network"
-    And the output contains "interact"
-    And the output contains "form"
-    And the output contains "emulate"
-    And the output contains "perf"
-    And the output contains "dialog"
-    And the output contains "config"
-    And the exit code is 0
+    Then stdout should contain "connect"
+    And stdout should contain "tabs"
+    And stdout should contain "navigate"
+    And stdout should contain "page"
+    And stdout should contain "js"
+    And stdout should contain "console"
+    And stdout should contain "network"
+    And stdout should contain "interact"
+    And stdout should contain "form"
+    And stdout should contain "emulate"
+    And stdout should contain "perf"
+    And stdout should contain "dialog"
+    And stdout should contain "config"
+    And the exit code should be 0
 
   Scenario: Show detailed examples for a specific command group
-    Given chrome-cli is installed
+    Given the chrome-cli binary is available
     When I run "chrome-cli examples navigate"
-    Then the output contains at least 3 examples
-    And each example includes a command string starting with "chrome-cli navigate"
-    And each example includes a description comment
-    And the exit code is 0
+    Then stdout should contain "chrome-cli navigate"
+    And stdout should contain "#"
+    And the output should have at least 3 example commands
+    And the exit code should be 0
 
   # --- Output Formats ---
 
   Scenario: Plain text output is the default
-    Given chrome-cli is installed
+    Given the chrome-cli binary is available
     When I run "chrome-cli examples"
-    Then the output is human-readable plain text
-    And the output does not start with "["
-    And the output does not start with "{"
-    And the exit code is 0
+    Then stdout should not start with "["
+    And stdout should not start with "{"
+    And the exit code should be 0
 
   Scenario: JSON output for summary listing
-    Given chrome-cli is installed
+    Given the chrome-cli binary is available
     When I run "chrome-cli examples --json"
-    Then the output is a valid JSON array
-    And each entry has a "command" field
-    And each entry has a "description" field
-    And each entry has an "examples" array
-    And each example has a "cmd" field
-    And each example has a "description" field
-    And the exit code is 0
+    Then stdout should be a valid JSON array
+    And each JSON entry should have a "command" field
+    And each JSON entry should have a "description" field
+    And each JSON entry should have an "examples" array
+    And the exit code should be 0
 
   Scenario: JSON output for a specific command group
-    Given chrome-cli is installed
+    Given the chrome-cli binary is available
     When I run "chrome-cli examples navigate --json"
-    Then the output is a valid JSON object
-    And the "command" field is "navigate"
-    And the "examples" array has at least 3 entries
-    And the exit code is 0
+    Then stdout should be a valid JSON object
+    And the JSON "command" field should be "navigate"
+    And the JSON "examples" array should have at least 3 entries
+    And the exit code should be 0
 
   Scenario: Pretty-printed JSON output
-    Given chrome-cli is installed
+    Given the chrome-cli binary is available
     When I run "chrome-cli examples --pretty"
-    Then the output is a valid JSON array
-    And the output contains indentation (multi-line formatted)
-    And the exit code is 0
+    Then stdout should be a valid JSON array
+    And stdout should be multi-line
+    And the exit code should be 0
 
   # --- Error Handling ---
 
   Scenario: Error on unknown command group
-    Given chrome-cli is installed
+    Given the chrome-cli binary is available
     When I run "chrome-cli examples nonexistent"
-    Then the exit code is 1
-    And stderr contains an error message about unknown command
+    Then the exit code should be 1
+    And stderr should contain "Unknown command group"
 
   # --- Coverage ---
 
   Scenario Outline: Each command group has at least 3 examples
-    Given chrome-cli is installed
+    Given the chrome-cli binary is available
     When I run "chrome-cli examples <group> --json"
-    Then the output is a valid JSON object
-    And the "examples" array has at least 3 entries
-    And the exit code is 0
+    Then stdout should be a valid JSON object
+    And the JSON "examples" array should have at least 3 entries
+    And the exit code should be 0
 
     Examples:
       | group    |

--- a/tests/features/examples.feature
+++ b/tests/features/examples.feature
@@ -1,0 +1,108 @@
+# File: tests/features/examples.feature
+#
+# Generated from: .claude/specs/29-built-in-examples-subcommand/requirements.md
+# Issue: #29
+
+Feature: Built-in Examples Subcommand
+  As a developer or AI agent using chrome-cli
+  I want a dedicated examples subcommand that prints usage examples
+  So that I can discover working CLI invocations without parsing --help output
+
+  # --- Happy Path ---
+
+  Scenario: List all command groups with summary examples
+    Given chrome-cli is installed
+    When I run "chrome-cli examples"
+    Then the output lists every command group with a description and one example
+    And the output contains "connect"
+    And the output contains "tabs"
+    And the output contains "navigate"
+    And the output contains "page"
+    And the output contains "js"
+    And the output contains "console"
+    And the output contains "network"
+    And the output contains "interact"
+    And the output contains "form"
+    And the output contains "emulate"
+    And the output contains "perf"
+    And the output contains "dialog"
+    And the output contains "config"
+    And the exit code is 0
+
+  Scenario: Show detailed examples for a specific command group
+    Given chrome-cli is installed
+    When I run "chrome-cli examples navigate"
+    Then the output contains at least 3 examples
+    And each example includes a command string starting with "chrome-cli navigate"
+    And each example includes a description comment
+    And the exit code is 0
+
+  # --- Output Formats ---
+
+  Scenario: Plain text output is the default
+    Given chrome-cli is installed
+    When I run "chrome-cli examples"
+    Then the output is human-readable plain text
+    And the output does not start with "["
+    And the output does not start with "{"
+    And the exit code is 0
+
+  Scenario: JSON output for summary listing
+    Given chrome-cli is installed
+    When I run "chrome-cli examples --json"
+    Then the output is a valid JSON array
+    And each entry has a "command" field
+    And each entry has a "description" field
+    And each entry has an "examples" array
+    And each example has a "cmd" field
+    And each example has a "description" field
+    And the exit code is 0
+
+  Scenario: JSON output for a specific command group
+    Given chrome-cli is installed
+    When I run "chrome-cli examples navigate --json"
+    Then the output is a valid JSON object
+    And the "command" field is "navigate"
+    And the "examples" array has at least 3 entries
+    And the exit code is 0
+
+  Scenario: Pretty-printed JSON output
+    Given chrome-cli is installed
+    When I run "chrome-cli examples --pretty"
+    Then the output is a valid JSON array
+    And the output contains indentation (multi-line formatted)
+    And the exit code is 0
+
+  # --- Error Handling ---
+
+  Scenario: Error on unknown command group
+    Given chrome-cli is installed
+    When I run "chrome-cli examples nonexistent"
+    Then the exit code is 1
+    And stderr contains an error message about unknown command
+
+  # --- Coverage ---
+
+  Scenario Outline: Each command group has at least 3 examples
+    Given chrome-cli is installed
+    When I run "chrome-cli examples <group> --json"
+    Then the output is a valid JSON object
+    And the "examples" array has at least 3 entries
+    And the exit code is 0
+
+    Examples:
+      | group    |
+      | connect  |
+      | tabs     |
+      | navigate |
+      | page     |
+      | dom      |
+      | js       |
+      | console  |
+      | network  |
+      | interact |
+      | form     |
+      | emulate  |
+      | perf     |
+      | dialog   |
+      | config   |


### PR DESCRIPTION
## Summary

- Adds a `chrome-cli examples` subcommand that prints usage examples for each command group in plain text or JSON, enabling AI agents and developers to discover working CLI invocations without parsing `--help` output
- Covers all 13 command groups (connect, tabs, navigate, page, dom, js, console, network, interact, form, emulate, perf, dialog, config) with 3–5 examples each
- Supports `--json` and `--pretty` output flags following the existing `OutputFormat` pattern

## Acceptance Criteria

From `.claude/specs/29-built-in-examples-subcommand/requirements.md`:

- [ ] AC1: `chrome-cli examples` lists all command groups with a brief description and one example each
- [ ] AC2: `chrome-cli examples <COMMAND>` shows 3–5 detailed examples for a specific command group
- [ ] AC3: `chrome-cli examples --json` outputs valid JSON array with `command`, `description`, and `examples` fields
- [ ] AC4: `chrome-cli examples navigate --json` outputs valid JSON object for a single command group
- [ ] AC5: `chrome-cli examples nonexistent` returns an error with non-zero exit code
- [ ] AC6: All command groups have at least 3 examples
- [ ] AC7: Plain text output is the default (comment-style `#` descriptions)
- [ ] AC8: `chrome-cli examples --pretty` outputs pretty-printed JSON

## Test Plan

From `.claude/specs/29-built-in-examples-subcommand/tasks.md` testing phase:

- [ ] BDD feature file (`tests/features/examples.feature`) with scenarios for all 8 acceptance criteria
- [ ] BDD step implementations (`tests/bdd.rs`) covering summary listing, per-command detail, JSON output, error handling
- [ ] Unit tests: `all_examples()` returns all command groups, each with ≥ 3 examples, no empty fields
- [ ] Unit tests: `execute_examples` with None/valid/unknown command args
- [ ] Unit tests: plain text formatting structure validation

## Specs

- Requirements: `.claude/specs/29-built-in-examples-subcommand/requirements.md`
- Design: `.claude/specs/29-built-in-examples-subcommand/design.md`
- Tasks: `.claude/specs/29-built-in-examples-subcommand/tasks.md`

Closes #29