### PR TITLE
fix: page find --role works as standalone search criterion (#97)

### DIFF
--- a/.claude/specs/97-fix-page-find-role-standalone/design.md
+++ b/.claude/specs/97-fix-page-find-role-standalone/design.md
@@ -1,0 +1,81 @@
+# Root Cause Analysis: page find --role does not work as standalone search criterion
+
+**Issue**: #97
+**Date**: 2026-02-15
+**Status**: Draft
+**Author**: Claude
+
+---
+
+## Root Cause
+
+The `execute_find()` function in `src/page.rs` (line 513) validates that at least one of `query` (positional text argument) or `--selector` is provided. If neither is present, it returns an error before ever checking whether `--role` was supplied. This means `--role` alone is rejected even though it represents a valid, independent search criterion.
+
+The downstream `search_tree()` function in `src/snapshot.rs` (lines 309-369) already handles this case correctly: when `query` is empty and a `role_filter` is provided, it matches all nodes of that role (line 346-348 treats an empty query as matching everything). The bug is entirely in the input validation gate, not in the search logic.
+
+### Affected Code
+
+| File | Lines | Role |
+|------|-------|------|
+| `src/page.rs` | 511-519 | `execute_find()` — input validation rejects `--role` without `query` or `--selector` |
+| `src/page.rs` | 544-546 | Accessibility search path — already passes `query.as_deref().unwrap_or("")` which would work with role-only |
+| `src/snapshot.rs` | 309-369 | `search_tree()` — already handles empty query + role filter correctly |
+
+### Triggering Conditions
+
+- User invokes `page find --role <role>` without a text query or `--selector`
+- `args.query` is `None` and `args.selector` is `None`
+- `args.role` is `Some(...)` but is never checked in the validation guard
+- Validation returns error prematurely
+
+---
+
+## Fix Strategy
+
+### Approach
+
+Expand the validation guard in `execute_find()` to also accept `--role` as a sufficient search criterion. The condition should reject the command only when **none** of `query`, `--selector`, or `--role` is provided.
+
+This is a single-line change to the `if` condition. No other code changes are required because `search_tree()` already handles the empty-query-with-role-filter case.
+
+### Changes
+
+| File | Change | Rationale |
+|------|--------|-----------|
+| `src/page.rs` (line 513) | Change `args.query.is_none() && args.selector.is_none()` to `args.query.is_none() && args.selector.is_none() && args.role.is_none()` | Allows `--role` as a standalone search criterion while preserving the requirement that *something* must be specified |
+
+### Blast Radius
+
+- **Direct impact**: `execute_find()` in `src/page.rs` — only the validation condition changes
+- **Indirect impact**: None — the accessibility search path (`search_tree()`) and CSS selector path are unaffected; both already handle the presence/absence of role correctly
+- **Risk level**: Low — the change only loosens validation; no execution paths are altered
+
+---
+
+## Regression Risk
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| Combined text+role search breaks | Low | AC2 regression test explicitly verifies this path |
+| Running `page find` with no arguments at all stops producing an error | Low | The new condition still requires at least one of query, selector, or role; AC-covered by existing Gherkin scenario "Neither query nor selector provided" which should be updated to also omit `--role` |
+| Error message becomes misleading | Low | Update the error message to mention `--role` as a valid alternative |
+
+---
+
+## Alternatives Considered
+
+| Option | Description | Why Not Selected |
+|--------|-------------|------------------|
+| Add a clap arg group requiring at least one of query/selector/role | Moves validation to clap, which would produce a different error message format | The existing in-function validation is simpler and consistent with how other commands validate; a one-line fix is preferable to restructuring argument parsing |
+
+---
+
+## Validation Checklist
+
+Before moving to TASKS phase:
+
+- [x] Root cause is identified with specific code references
+- [x] Fix is minimal — no unrelated refactoring
+- [x] Blast radius is assessed
+- [x] Regression risks are documented with mitigations
+- [x] Fix follows existing project patterns (per `structure.md`)

--- a/.claude/specs/97-fix-page-find-role-standalone/feature.gherkin
+++ b/.claude/specs/97-fix-page-find-role-standalone/feature.gherkin
@@ -1,0 +1,51 @@
+# File: tests/features/element-finding.feature (additions)
+#
+# Generated from: .claude/specs/97-fix-page-find-role-standalone/requirements.md
+# Issue: #97
+# Type: Defect regression
+
+@regression
+Feature: page find --role as standalone search criterion
+  The `page find` command previously rejected `--role` as a standalone
+  search criterion, requiring a text query or `--selector` even when
+  `--role` alone was sufficient. This was fixed by including `--role`
+  in the input validation guard.
+
+  Background:
+    Given Chrome is running with CDP enabled
+    And a page is loaded with known interactive elements
+
+  # --- Bug Is Fixed ---
+
+  @regression
+  Scenario: Role-only search returns matching elements
+    Given the page contains a textbox and a button
+    When I run "chrome-cli page find --role textbox"
+    Then a JSON array is returned
+    And each element has role "textbox"
+    And each element includes "uid", "role", "name", and "boundingBox" fields
+    And the exit code is 0
+
+  # --- Related Behavior Still Works ---
+
+  @regression
+  Scenario: Combined role and text query still filters correctly
+    Given the page contains a link "Next" and a button "Next"
+    When I run "chrome-cli page find Next --role link"
+    Then only the link element with name "Next" is returned
+    And the button "Next" is not in the results
+
+  # --- Edge Case ---
+
+  @regression
+  Scenario: Role-only search with no matches returns empty array
+    Given the page is loaded
+    When I run "chrome-cli page find --role nonexistent-role"
+    Then an empty JSON array "[]" is returned
+    And the exit code is 0
+
+  @regression
+  Scenario: No search criterion provided returns error
+    When I run "chrome-cli page find"
+    Then an error is returned with message "a text query, --selector, or --role is required"
+    And the exit code is 1

--- a/.claude/specs/97-fix-page-find-role-standalone/requirements.md
+++ b/.claude/specs/97-fix-page-find-role-standalone/requirements.md
@@ -1,0 +1,103 @@
+# Defect Report: page find --role does not work as standalone search criterion
+
+**Issue**: #97
+**Date**: 2026-02-15
+**Status**: Draft
+**Author**: Claude
+**Severity**: Medium
+**Related Spec**: `.claude/specs/15-element-finding/` *(if exists — covers the original `page find` feature)*
+
+---
+
+## Reproduction
+
+### Steps to Reproduce
+
+1. `chrome-cli connect --launch --headless`
+2. `chrome-cli navigate https://www.google.com --wait-until load`
+3. `chrome-cli page find --role textbox`
+4. Error: `{"error":"either a text query or --selector is required","code":1}`
+
+### Environment
+
+| Factor | Value |
+|--------|-------|
+| **OS / Platform** | macOS (Darwin 25.3.0) |
+| **Version / Commit** | `c584d2d` (main) |
+| **Browser / Runtime** | Chrome via CDP |
+| **Configuration** | Default |
+
+### Frequency
+
+Always
+
+---
+
+## Expected vs Actual
+
+| | Description |
+|---|-------------|
+| **Expected** | `page find --role textbox` returns a JSON array of matching elements with their UIDs, roles, and names — consistent with `--help` documentation showing `--role` as a standalone search option |
+| **Actual** | Returns error `{"error":"either a text query or --selector is required","code":1}` because validation in `execute_find()` requires either `query` or `selector` to be present, ignoring `--role` as a valid standalone criterion |
+
+### Error Output
+
+```json
+{"error":"either a text query or --selector is required","code":1}
+```
+
+---
+
+## Acceptance Criteria
+
+**IMPORTANT: Each criterion becomes a Gherkin BDD test scenario.**
+
+### AC1: Role-only search works
+
+**Given** a page is loaded with interactive elements
+**When** I run `page find --role textbox`
+**Then** the output is a JSON array of matching elements with their UIDs, roles, and names
+
+### AC2: Role filter still works with text query
+
+**Given** a page is loaded
+**When** I run `page find "Submit" --role button`
+**Then** only elements matching both the text and role are returned
+
+### AC3: Empty role result returns empty array
+
+**Given** a page is loaded
+**When** I run `page find --role nonexistent-role`
+**Then** the output is an empty JSON array `[]` (not an error)
+
+---
+
+## Functional Requirements
+
+| ID | Requirement | Priority |
+|----|-------------|----------|
+| FR1 | `--role` must be accepted as a standalone search criterion (no text or `--selector` required) | Must |
+| FR2 | `--role` combined with text query continues to filter by both role and text | Should |
+| FR3 | When `--role` is used standalone, all elements matching the role are returned (up to `--limit`) | Must |
+
+---
+
+## Out of Scope
+
+- Adding new roles beyond what the accessibility tree supports
+- Role validation against a known list
+- Changing `--selector` or text query behavior when `--role` is not involved
+
+---
+
+## Validation Checklist
+
+Before moving to PLAN phase:
+
+- [x] Reproduction steps are repeatable and specific
+- [x] Expected vs actual behavior is clearly stated
+- [x] Severity is assessed
+- [x] Acceptance criteria use Given/When/Then format
+- [x] At least one regression scenario is included (AC2)
+- [x] Fix scope is minimal — no feature work mixed in
+- [x] Out of scope is defined

--- a/.claude/specs/97-fix-page-find-role-standalone/tasks.md
+++ b/.claude/specs/97-fix-page-find-role-standalone/tasks.md
@@ -1,0 +1,70 @@
+# Tasks: page find --role does not work as standalone search criterion
+
+**Issue**: #97
+**Date**: 2026-02-15
+**Status**: Planning
+**Author**: Claude
+
+---
+
+## Summary
+
+| Task | Description | Status |
+|------|-------------|--------|
+| T001 | Fix the validation guard and error message | [ ] |
+| T002 | Add regression test scenarios | [ ] |
+| T003 | Verify no regressions | [ ] |
+
+---
+
+### T001: Fix the Defect
+
+**File(s)**: `src/page.rs`
+**Type**: Modify
+**Depends**: None
+**Acceptance**:
+- [ ] Validation guard at line 513 accepts `--role` as a standalone criterion (condition becomes `args.query.is_none() && args.selector.is_none() && args.role.is_none()`)
+- [ ] Error message updated to mention `--role` as a valid option (e.g., `"a text query, --selector, or --role is required"`)
+- [ ] `page find --role textbox` no longer returns an error
+- [ ] `page find` with no arguments still returns an error
+- [ ] No unrelated changes in the diff
+
+**Notes**: Follow the fix strategy from design.md. The `search_tree()` function in `snapshot.rs` already handles empty query + role filter correctly — no changes needed there.
+
+### T002: Add Regression Test
+
+**File(s)**: `tests/features/element-finding.feature`, `.claude/specs/97-fix-page-find-role-standalone/feature.gherkin`
+**Type**: Modify
+**Depends**: T001
+**Acceptance**:
+- [ ] Gherkin scenario for role-only search added (AC1)
+- [ ] Gherkin scenario for empty role result added (AC3)
+- [ ] Existing "Combined role and text query" scenario preserved (AC2 — already exists)
+- [ ] Existing "Neither query nor selector provided" scenario updated to reflect new error message
+- [ ] All scenarios tagged `@regression` in the spec feature file
+- [ ] Tests pass with the fix applied
+
+### T003: Verify No Regressions
+
+**File(s)**: existing test files
+**Type**: Verify (no file changes)
+**Depends**: T001, T002
+**Acceptance**:
+- [ ] All existing tests pass (`cargo test`)
+- [ ] `cargo clippy` passes with no new warnings
+- [ ] `page find <text>` still works
+- [ ] `page find --selector <css>` still works
+- [ ] `page find <text> --role <role>` still works
+- [ ] `page find` with no arguments still errors
+
+---
+
+## Validation Checklist
+
+Before moving to IMPLEMENT phase:
+
+- [x] Tasks are focused on the fix — no feature work
+- [x] Regression test is included (T002)
+- [x] Each task has verifiable acceptance criteria
+- [x] No scope creep beyond the defect
+- [x] File paths reference actual project structure (per `structure.md`)

--- a/src/page.rs
+++ b/src/page.rs
@@ -509,10 +509,10 @@ async fn capture_snapshot(
 }
 
 async fn execute_find(global: &GlobalOpts, args: &PageFindArgs) -> Result<(), AppError> {
-    // Validate: at least one of query or selector must be provided
-    if args.query.is_none() && args.selector.is_none() {
+    // Validate: at least one of query, selector, or role must be provided
+    if args.query.is_none() && args.selector.is_none() && args.role.is_none() {
         return Err(AppError {
-            message: "either a text query or --selector is required".to_string(),
+            message: "a text query, --selector, or --role is required".to_string(),
             code: ExitCode::GeneralError,
             custom_json: None,
         });

--- a/tests/features/element-finding.feature
+++ b/tests/features/element-finding.feature
@@ -88,6 +88,24 @@ Feature: Element finding by text, CSS selector, and accessibility attributes
     Then only the link element with name "Next" is returned
     And the button "Next" is not in the results
 
+  # --- Role-Only Search (Issue #97) ---
+
+  @regression
+  Scenario: Role-only search returns matching elements
+    Given the page contains a textbox and a button
+    When I run "chrome-cli page find --role textbox"
+    Then a JSON array is returned
+    And each element has role "textbox"
+    And each element includes "uid", "role", "name", and "boundingBox" fields
+    And the exit code is 0
+
+  @regression
+  Scenario: Role-only search with no matches returns empty array
+    Given the page is loaded
+    When I run "chrome-cli page find --role nonexistent-role"
+    Then an empty JSON array "[]" is returned
+    And the exit code is 0
+
   # --- Edge Cases ---
 
   Scenario: No matches found returns empty array
@@ -98,7 +116,7 @@ Feature: Element finding by text, CSS selector, and accessibility attributes
 
   # --- Error Cases ---
 
-  Scenario: Neither query nor selector provided
+  Scenario: Neither query, selector, nor role provided
     When I run "chrome-cli page find"
-    Then an error is returned with message "either a text query or --selector is required"
+    Then an error is returned with message "a text query, --selector, or --role is required"
     And the exit code is 1


### PR DESCRIPTION
## Summary

- Fixed validation guard in `execute_find()` to accept `--role` as a standalone search criterion, matching the documented `--help` behavior
- Updated error message to include `--role` as a valid option: `"a text query, --selector, or --role is required"`
- Added regression test scenarios for role-only search and empty role results

## Acceptance Criteria

From `.claude/specs/97-fix-page-find-role-standalone/requirements.md`:

- [ ] AC1: `page find --role textbox` returns a JSON array of matching elements with UIDs, roles, and names
- [ ] AC2: `page find "Submit" --role button` filters by both text and role
- [ ] AC3: `page find --role nonexistent-role` returns empty array `[]` (not an error)

## Test Plan

From `.claude/specs/97-fix-page-find-role-standalone/tasks.md` testing phase:

- [ ] Regression: Role-only search returns matching elements (AC1)
- [ ] Regression: Role-only search with no matches returns empty array (AC3)
- [ ] Regression: Combined role and text query still filters correctly (AC2)
- [ ] Regression: No search criterion provided still returns error
- [ ] Verify: `cargo test` passes with no failures
- [ ] Verify: `cargo clippy` passes with no new warnings

## Specs

- Requirements: `.claude/specs/97-fix-page-find-role-standalone/requirements.md`
- Design: `.claude/specs/97-fix-page-find-role-standalone/design.md`
- Tasks: `.claude/specs/97-fix-page-find-role-standalone/tasks.md`

Closes #97