### PR TITLE
fix: update x86_64-apple-darwin test expectation to macos-latest

### DIFF
--- a/tests/features/release-pipeline.feature
+++ b/tests/features/release-pipeline.feature
@@ -57,7 +57,7 @@ Feature: Cross-platform release pipeline
     Examples:
       | target                        | runner            |
       | aarch64-apple-darwin          | macos-latest      |
-      | x86_64-apple-darwin           | macos-13          |
+      | x86_64-apple-darwin           | macos-latest      |
       | x86_64-unknown-linux-gnu      | ubuntu-latest     |
       | aarch64-unknown-linux-gnu     | ubuntu-24.04-arm  |
       | x86_64-pc-windows-msvc        | windows-latest    |


### PR DESCRIPTION
Updates the BDD test to expect `macos-latest` instead of `macos-13` for the `x86_64-apple-darwin` release target, matching the workflow change.