### PR TITLE
feat: add held-key click support (#291)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,8 @@ target/
 .cursor/
 
 # Test fixtures
-tests/fixtures/
+tests/fixtures/*
+!tests/fixtures/click-held-keys.html
 
 # Codex local settings
 .codex/settings.local.json

--- a/man/agentchrome-interact-click-at.1
+++ b/man/agentchrome-interact-click-at.1
@@ -4,9 +4,9 @@
 .SH NAME
 click\-at \- Click at viewport coordinates
 .SH SYNOPSIS
-\fBclick\-at\fR [\fB\-\-relative\-to\fR] [\fB\-\-double\fR] [\fB\-\-right\fR] [\fB\-\-include\-snapshot\fR] [\fB\-\-compact\fR] [\fB\-\-wait\-until\fR] [\fB\-h\fR|\fB\-\-help\fR] <\fIX\fR> <\fIY\fR>
+\fBclick\-at\fR [\fB\-\-relative\-to\fR] [\fB\-\-double\fR] [\fB\-\-right\fR] [\fB\-\-hold\fR] [\fB\-\-include\-snapshot\fR] [\fB\-\-compact\fR] [\fB\-\-wait\-until\fR] [\fB\-h\fR|\fB\-\-help\fR] <\fIX\fR> <\fIY\fR>
 .SH DESCRIPTION
-Click at specific viewport coordinates (X, Y in pixels). Useful when targeting elements that are not in the accessibility tree or for precise coordinate\-based interactions. Use \-\-double for double\-click or \-\-right for right\-click.
+Click at specific viewport coordinates (X, Y in pixels). Useful when targeting elements that are not in the accessibility tree or for precise coordinate\-based interactions. Use \-\-double for double\-click or \-\-right for right\-click. Use \-\-hold to hold one or more keys while dispatching the click.
 .SH OPTIONS
 .TP
 \fB\-\-relative\-to\fR \fI<RELATIVE_TO>\fR
@@ -17,6 +17,9 @@ Perform a double\-click instead of single click (conflicts with \-\-right)
 .TP
 \fB\-\-right\fR
 Perform a right\-click (context menu) instead of left click (conflicts with \-\-double)
+.TP
+\fB\-\-hold\fR \fI<KEY>\fR
+Hold a key while dispatching the click. Uses the same key names as `interact key`. Can be repeated
 .TP
 \fB\-\-include\-snapshot\fR
 Include updated accessibility snapshot in output
@@ -56,6 +59,9 @@ EXAMPLES:
 
   # Double\-click at coordinates
   agentchrome interact click\-at 100 200 \-\-double
+
+  # Hold Space and Alt while clicking coordinates
+  agentchrome interact click\-at 100 200 \-\-hold Space \-\-hold Alt
 .SH CAPABILITIES
 .PP
 Mouse, keyboard, and scroll interactions
@@ -71,6 +77,9 @@ Perform a double-click instead of single click (conflicts with --right)
 .TP
 .B --right
 Perform a right-click (context menu) instead of left click (conflicts with --double)
+.TP
+.B --hold
+Hold a key while dispatching the click. Uses the same key names as `interact key`. Can be repeated
 .TP
 .B --include-snapshot
 Include updated accessibility snapshot in output
@@ -98,6 +107,9 @@ Perform a double-click instead of single click (conflicts with --right)
 .TP
 .B --right
 Perform a right-click (context menu) instead of left click (conflicts with --double)
+.TP
+.B --hold
+Hold a key while dispatching the click. Uses the same key names as `interact key`. Can be repeated
 .TP
 .B --include-snapshot
 Include updated accessibility snapshot in output
@@ -281,6 +293,12 @@ Click an element by CSS selector
 .TP
 .B \`agentchrome interact click s12 --wait-until networkidle\`
 Click and wait for network idle (for SPA navigation)
+.TP
+.B \`agentchrome interact click s5 --hold Shift\`
+Hold Shift while clicking an element
+.TP
+.B \`agentchrome interact click-at 100 200 --hold Space --hold Alt\`
+Hold multiple keys while clicking coordinates
 .TP
 .B \`agentchrome interact type "Hello, world!"\`
 Type text into the focused element

--- a/man/agentchrome-interact-click.1
+++ b/man/agentchrome-interact-click.1
@@ -4,9 +4,9 @@
 .SH NAME
 click \- Click an element by UID or CSS selector
 .SH SYNOPSIS
-\fBclick\fR [\fB\-\-double\fR] [\fB\-\-right\fR] [\fB\-\-include\-snapshot\fR] [\fB\-\-compact\fR] [\fB\-\-wait\-until\fR] [\fB\-h\fR|\fB\-\-help\fR] <\fITARGET\fR>
+\fBclick\fR [\fB\-\-double\fR] [\fB\-\-right\fR] [\fB\-\-hold\fR] [\fB\-\-include\-snapshot\fR] [\fB\-\-compact\fR] [\fB\-\-wait\-until\fR] [\fB\-h\fR|\fB\-\-help\fR] <\fITARGET\fR>
 .SH DESCRIPTION
-Click an element identified by UID (from \*(Aqpage snapshot\*(Aq, e.g., \*(Aqs5\*(Aq) or CSS selector (prefixed with \*(Aqcss:\*(Aq, e.g., \*(Aqcss:#submit\*(Aq). By default, performs a left single\-click at the element\*(Aqs center. Use \-\-double for double\-click or \-\-right for right\-click (context menu). These flags are mutually exclusive.
+Click an element identified by UID (from \*(Aqpage snapshot\*(Aq, e.g., \*(Aqs5\*(Aq) or CSS selector (prefixed with \*(Aqcss:\*(Aq, e.g., \*(Aqcss:#submit\*(Aq). By default, performs a left single\-click at the element\*(Aqs center. Use \-\-double for double\-click or \-\-right for right\-click (context menu). These flags are mutually exclusive. Use \-\-hold to hold one or more keys while dispatching the click.
 .SH OPTIONS
 .TP
 \fB\-\-double\fR
@@ -14,6 +14,9 @@ Perform a double\-click instead of single click (conflicts with \-\-right)
 .TP
 \fB\-\-right\fR
 Perform a right\-click (context menu) instead of left click (conflicts with \-\-double)
+.TP
+\fB\-\-hold\fR \fI<KEY>\fR
+Hold a key while dispatching the click. Uses the same key names as `interact key`. Can be repeated
 .TP
 \fB\-\-include\-snapshot\fR
 Include updated accessibility snapshot in output
@@ -56,6 +59,9 @@ EXAMPLES:
 
   # Right\-click (context menu)
   agentchrome interact click s5 \-\-right
+
+  # Shift\-click an element
+  agentchrome interact click s5 \-\-hold Shift
 .SH CAPABILITIES
 .PP
 Mouse, keyboard, and scroll interactions
@@ -71,6 +77,9 @@ Perform a double-click instead of single click (conflicts with --right)
 .TP
 .B --right
 Perform a right-click (context menu) instead of left click (conflicts with --double)
+.TP
+.B --hold
+Hold a key while dispatching the click. Uses the same key names as `interact key`. Can be repeated
 .TP
 .B --include-snapshot
 Include updated accessibility snapshot in output
@@ -98,6 +107,9 @@ Perform a double-click instead of single click (conflicts with --right)
 .TP
 .B --right
 Perform a right-click (context menu) instead of left click (conflicts with --double)
+.TP
+.B --hold
+Hold a key while dispatching the click. Uses the same key names as `interact key`. Can be repeated
 .TP
 .B --include-snapshot
 Include updated accessibility snapshot in output
@@ -281,6 +293,12 @@ Click an element by CSS selector
 .TP
 .B \`agentchrome interact click s12 --wait-until networkidle\`
 Click and wait for network idle (for SPA navigation)
+.TP
+.B \`agentchrome interact click s5 --hold Shift\`
+Hold Shift while clicking an element
+.TP
+.B \`agentchrome interact click-at 100 200 --hold Space --hold Alt\`
+Hold multiple keys while clicking coordinates
 .TP
 .B \`agentchrome interact type "Hello, world!"\`
 Type text into the focused element

--- a/man/agentchrome-interact-drag-at.1
+++ b/man/agentchrome-interact-drag-at.1
@@ -61,6 +61,9 @@ Perform a double-click instead of single click (conflicts with --right)
 .B --right
 Perform a right-click (context menu) instead of left click (conflicts with --double)
 .TP
+.B --hold
+Hold a key while dispatching the click. Uses the same key names as `interact key`. Can be repeated
+.TP
 .B --include-snapshot
 Include updated accessibility snapshot in output
 .TP
@@ -87,6 +90,9 @@ Perform a double-click instead of single click (conflicts with --right)
 .TP
 .B --right
 Perform a right-click (context menu) instead of left click (conflicts with --double)
+.TP
+.B --hold
+Hold a key while dispatching the click. Uses the same key names as `interact key`. Can be repeated
 .TP
 .B --include-snapshot
 Include updated accessibility snapshot in output
@@ -270,6 +276,12 @@ Click an element by CSS selector
 .TP
 .B \`agentchrome interact click s12 --wait-until networkidle\`
 Click and wait for network idle (for SPA navigation)
+.TP
+.B \`agentchrome interact click s5 --hold Shift\`
+Hold Shift while clicking an element
+.TP
+.B \`agentchrome interact click-at 100 200 --hold Space --hold Alt\`
+Hold multiple keys while clicking coordinates
 .TP
 .B \`agentchrome interact type "Hello, world!"\`
 Type text into the focused element

--- a/man/agentchrome-interact-drag.1
+++ b/man/agentchrome-interact-drag.1
@@ -46,6 +46,9 @@ Perform a double-click instead of single click (conflicts with --right)
 .B --right
 Perform a right-click (context menu) instead of left click (conflicts with --double)
 .TP
+.B --hold
+Hold a key while dispatching the click. Uses the same key names as `interact key`. Can be repeated
+.TP
 .B --include-snapshot
 Include updated accessibility snapshot in output
 .TP
@@ -72,6 +75,9 @@ Perform a double-click instead of single click (conflicts with --right)
 .TP
 .B --right
 Perform a right-click (context menu) instead of left click (conflicts with --double)
+.TP
+.B --hold
+Hold a key while dispatching the click. Uses the same key names as `interact key`. Can be repeated
 .TP
 .B --include-snapshot
 Include updated accessibility snapshot in output
@@ -255,6 +261,12 @@ Click an element by CSS selector
 .TP
 .B \`agentchrome interact click s12 --wait-until networkidle\`
 Click and wait for network idle (for SPA navigation)
+.TP
+.B \`agentchrome interact click s5 --hold Shift\`
+Hold Shift while clicking an element
+.TP
+.B \`agentchrome interact click-at 100 200 --hold Space --hold Alt\`
+Hold multiple keys while clicking coordinates
 .TP
 .B \`agentchrome interact type "Hello, world!"\`
 Type text into the focused element

--- a/man/agentchrome-interact-hover.1
+++ b/man/agentchrome-interact-hover.1
@@ -43,6 +43,9 @@ Perform a double-click instead of single click (conflicts with --right)
 .B --right
 Perform a right-click (context menu) instead of left click (conflicts with --double)
 .TP
+.B --hold
+Hold a key while dispatching the click. Uses the same key names as `interact key`. Can be repeated
+.TP
 .B --include-snapshot
 Include updated accessibility snapshot in output
 .TP
@@ -69,6 +72,9 @@ Perform a double-click instead of single click (conflicts with --right)
 .TP
 .B --right
 Perform a right-click (context menu) instead of left click (conflicts with --double)
+.TP
+.B --hold
+Hold a key while dispatching the click. Uses the same key names as `interact key`. Can be repeated
 .TP
 .B --include-snapshot
 Include updated accessibility snapshot in output
@@ -252,6 +258,12 @@ Click an element by CSS selector
 .TP
 .B \`agentchrome interact click s12 --wait-until networkidle\`
 Click and wait for network idle (for SPA navigation)
+.TP
+.B \`agentchrome interact click s5 --hold Shift\`
+Hold Shift while clicking an element
+.TP
+.B \`agentchrome interact click-at 100 200 --hold Space --hold Alt\`
+Hold multiple keys while clicking coordinates
 .TP
 .B \`agentchrome interact type "Hello, world!"\`
 Type text into the focused element

--- a/man/agentchrome-interact-key.1
+++ b/man/agentchrome-interact-key.1
@@ -52,6 +52,9 @@ Perform a double-click instead of single click (conflicts with --right)
 .B --right
 Perform a right-click (context menu) instead of left click (conflicts with --double)
 .TP
+.B --hold
+Hold a key while dispatching the click. Uses the same key names as `interact key`. Can be repeated
+.TP
 .B --include-snapshot
 Include updated accessibility snapshot in output
 .TP
@@ -78,6 +81,9 @@ Perform a double-click instead of single click (conflicts with --right)
 .TP
 .B --right
 Perform a right-click (context menu) instead of left click (conflicts with --double)
+.TP
+.B --hold
+Hold a key while dispatching the click. Uses the same key names as `interact key`. Can be repeated
 .TP
 .B --include-snapshot
 Include updated accessibility snapshot in output
@@ -261,6 +267,12 @@ Click an element by CSS selector
 .TP
 .B \`agentchrome interact click s12 --wait-until networkidle\`
 Click and wait for network idle (for SPA navigation)
+.TP
+.B \`agentchrome interact click s5 --hold Shift\`
+Hold Shift while clicking an element
+.TP
+.B \`agentchrome interact click-at 100 200 --hold Space --hold Alt\`
+Hold multiple keys while clicking coordinates
 .TP
 .B \`agentchrome interact type "Hello, world!"\`
 Type text into the focused element

--- a/man/agentchrome-interact-mousedown-at.1
+++ b/man/agentchrome-interact-mousedown-at.1
@@ -67,6 +67,9 @@ Perform a double-click instead of single click (conflicts with --right)
 .B --right
 Perform a right-click (context menu) instead of left click (conflicts with --double)
 .TP
+.B --hold
+Hold a key while dispatching the click. Uses the same key names as `interact key`. Can be repeated
+.TP
 .B --include-snapshot
 Include updated accessibility snapshot in output
 .TP
@@ -93,6 +96,9 @@ Perform a double-click instead of single click (conflicts with --right)
 .TP
 .B --right
 Perform a right-click (context menu) instead of left click (conflicts with --double)
+.TP
+.B --hold
+Hold a key while dispatching the click. Uses the same key names as `interact key`. Can be repeated
 .TP
 .B --include-snapshot
 Include updated accessibility snapshot in output
@@ -276,6 +282,12 @@ Click an element by CSS selector
 .TP
 .B \`agentchrome interact click s12 --wait-until networkidle\`
 Click and wait for network idle (for SPA navigation)
+.TP
+.B \`agentchrome interact click s5 --hold Shift\`
+Hold Shift while clicking an element
+.TP
+.B \`agentchrome interact click-at 100 200 --hold Space --hold Alt\`
+Hold multiple keys while clicking coordinates
 .TP
 .B \`agentchrome interact type "Hello, world!"\`
 Type text into the focused element

--- a/man/agentchrome-interact-mouseup-at.1
+++ b/man/agentchrome-interact-mouseup-at.1
@@ -67,6 +67,9 @@ Perform a double-click instead of single click (conflicts with --right)
 .B --right
 Perform a right-click (context menu) instead of left click (conflicts with --double)
 .TP
+.B --hold
+Hold a key while dispatching the click. Uses the same key names as `interact key`. Can be repeated
+.TP
 .B --include-snapshot
 Include updated accessibility snapshot in output
 .TP
@@ -93,6 +96,9 @@ Perform a double-click instead of single click (conflicts with --right)
 .TP
 .B --right
 Perform a right-click (context menu) instead of left click (conflicts with --double)
+.TP
+.B --hold
+Hold a key while dispatching the click. Uses the same key names as `interact key`. Can be repeated
 .TP
 .B --include-snapshot
 Include updated accessibility snapshot in output
@@ -276,6 +282,12 @@ Click an element by CSS selector
 .TP
 .B \`agentchrome interact click s12 --wait-until networkidle\`
 Click and wait for network idle (for SPA navigation)
+.TP
+.B \`agentchrome interact click s5 --hold Shift\`
+Hold Shift while clicking an element
+.TP
+.B \`agentchrome interact click-at 100 200 --hold Space --hold Alt\`
+Hold multiple keys while clicking coordinates
 .TP
 .B \`agentchrome interact type "Hello, world!"\`
 Type text into the focused element

--- a/man/agentchrome-interact-scroll.1
+++ b/man/agentchrome-interact-scroll.1
@@ -96,6 +96,9 @@ Perform a double-click instead of single click (conflicts with --right)
 .B --right
 Perform a right-click (context menu) instead of left click (conflicts with --double)
 .TP
+.B --hold
+Hold a key while dispatching the click. Uses the same key names as `interact key`. Can be repeated
+.TP
 .B --include-snapshot
 Include updated accessibility snapshot in output
 .TP
@@ -122,6 +125,9 @@ Perform a double-click instead of single click (conflicts with --right)
 .TP
 .B --right
 Perform a right-click (context menu) instead of left click (conflicts with --double)
+.TP
+.B --hold
+Hold a key while dispatching the click. Uses the same key names as `interact key`. Can be repeated
 .TP
 .B --include-snapshot
 Include updated accessibility snapshot in output
@@ -305,6 +311,12 @@ Click an element by CSS selector
 .TP
 .B \`agentchrome interact click s12 --wait-until networkidle\`
 Click and wait for network idle (for SPA navigation)
+.TP
+.B \`agentchrome interact click s5 --hold Shift\`
+Hold Shift while clicking an element
+.TP
+.B \`agentchrome interact click-at 100 200 --hold Space --hold Alt\`
+Hold multiple keys while clicking coordinates
 .TP
 .B \`agentchrome interact type "Hello, world!"\`
 Type text into the focused element

--- a/man/agentchrome-interact-type.1
+++ b/man/agentchrome-interact-type.1
@@ -46,6 +46,9 @@ Perform a double-click instead of single click (conflicts with --right)
 .B --right
 Perform a right-click (context menu) instead of left click (conflicts with --double)
 .TP
+.B --hold
+Hold a key while dispatching the click. Uses the same key names as `interact key`. Can be repeated
+.TP
 .B --include-snapshot
 Include updated accessibility snapshot in output
 .TP
@@ -72,6 +75,9 @@ Perform a double-click instead of single click (conflicts with --right)
 .TP
 .B --right
 Perform a right-click (context menu) instead of left click (conflicts with --double)
+.TP
+.B --hold
+Hold a key while dispatching the click. Uses the same key names as `interact key`. Can be repeated
 .TP
 .B --include-snapshot
 Include updated accessibility snapshot in output
@@ -255,6 +261,12 @@ Click an element by CSS selector
 .TP
 .B \`agentchrome interact click s12 --wait-until networkidle\`
 Click and wait for network idle (for SPA navigation)
+.TP
+.B \`agentchrome interact click s5 --hold Shift\`
+Hold Shift while clicking an element
+.TP
+.B \`agentchrome interact click-at 100 200 --hold Space --hold Alt\`
+Hold multiple keys while clicking coordinates
 .TP
 .B \`agentchrome interact type "Hello, world!"\`
 Type text into the focused element

--- a/man/agentchrome-interact.1
+++ b/man/agentchrome-interact.1
@@ -80,6 +80,9 @@ Perform a double-click instead of single click (conflicts with --right)
 .B --right
 Perform a right-click (context menu) instead of left click (conflicts with --double)
 .TP
+.B --hold
+Hold a key while dispatching the click. Uses the same key names as `interact key`. Can be repeated
+.TP
 .B --include-snapshot
 Include updated accessibility snapshot in output
 .TP
@@ -106,6 +109,9 @@ Perform a double-click instead of single click (conflicts with --right)
 .TP
 .B --right
 Perform a right-click (context menu) instead of left click (conflicts with --double)
+.TP
+.B --hold
+Hold a key while dispatching the click. Uses the same key names as `interact key`. Can be repeated
 .TP
 .B --include-snapshot
 Include updated accessibility snapshot in output
@@ -289,6 +295,12 @@ Click an element by CSS selector
 .TP
 .B \`agentchrome interact click s12 --wait-until networkidle\`
 Click and wait for network idle (for SPA navigation)
+.TP
+.B \`agentchrome interact click s5 --hold Shift\`
+Hold Shift while clicking an element
+.TP
+.B \`agentchrome interact click-at 100 200 --hold Space --hold Alt\`
+Hold multiple keys while clicking coordinates
 .TP
 .B \`agentchrome interact type "Hello, world!"\`
 Type text into the focused element

--- a/specs/feature-mouse-interactions/design.md
+++ b/specs/feature-mouse-interactions/design.md
@@ -1,7 +1,7 @@
 # Design: Mouse Interactions
 
-**Issues**: #14
-**Date**: 2026-02-13
+**Issues**: #14, #291
+**Date**: 2026-05-26
 **Status**: Draft
 **Author**: Claude (writing-specs)
 
@@ -110,6 +110,40 @@ The core flow for all interaction commands is: resolve target → get element co
 6. Output result
 ```
 
+### Data Flow — `interact click s1 --hold Shift`
+
+```
+1. User runs: agentchrome interact click s1 --hold Shift
+2. CLI layer parses → ClickArgs { target: "s1", hold: ["Shift"], ... }
+3. validate_held_keys(["Shift"]) runs before session setup and rejects invalid or duplicate keys
+4. setup_session_with_interceptors() → CdpClient + ManagedSession
+5. Resolve target "s1" to click coordinates using the existing click flow
+6. Press held keys in declared order via Input.dispatchKeyEvent:
+   - keyDown { key: "Shift", code: "ShiftLeft", modifiers: 8, windowsVirtualKeyCode: 16 }
+7. Dispatch click via Input.dispatchMouseEvent with modifiers: 8 on every mousePressed/mouseReleased payload
+8. Release held keys in reverse order via Input.dispatchKeyEvent:
+   - keyUp { key: "Shift", code: "ShiftLeft", modifiers: 0, windowsVirtualKeyCode: 16 }
+9. Build the normal ClickResult; no new output field is required
+```
+
+### Data Flow — `interact click-at 100 200 --hold Space --hold Alt`
+
+```
+1. User runs: agentchrome interact click-at 100 200 --hold Space --hold Alt
+2. CLI layer parses → ClickAtArgs { x: 100.0, y: 200.0, hold: ["Space", "Alt"], ... }
+3. validate_held_keys(["Space", "Alt"]) runs before session setup
+4. setup_session_with_interceptors() → CdpClient + ManagedSession
+5. Resolve click coordinates, including --relative-to and frame offset handling when supplied
+6. Press held keys in declared order:
+   - keyDown Space without text synthesis
+   - keyDown Alt with modifiers: 1
+7. Dispatch click via Input.dispatchMouseEvent with modifiers: 1 on every mouse payload
+8. Release held keys in reverse order:
+   - keyUp Alt
+   - keyUp Space
+9. Build the normal ClickAtResult; no new output field is required
+```
+
 ### Data Flow — `interact hover s3`
 
 ```
@@ -155,6 +189,7 @@ The core flow for all interaction commands is: resolve target → get element co
 | `--double` | click, click-at | bool | Double-click instead of single click |
 | `--right` | click, click-at | bool | Right-click (context menu) instead of left click |
 | `--include-snapshot` | click, click-at, hover, drag | bool | Include updated accessibility snapshot in output |
+| `--hold <KEY>` | click, click-at | repeatable key name | Hold any valid AgentChrome key while dispatching the click |
 
 ### Request / Response Schemas
 
@@ -162,7 +197,7 @@ The core flow for all interaction commands is: resolve target → get element co
 
 **Input (CLI args):**
 ```
-agentchrome interact click <TARGET> [--double] [--right] [--include-snapshot] [--tab ID]
+agentchrome interact click <TARGET> [--double] [--right] [--hold KEY]... [--include-snapshot] [--tab ID]
 ```
 
 **Output (success — JSON):**
@@ -223,6 +258,11 @@ Clicked s1
 | 5 (ProtocolError) | CDP protocol error |
 
 #### `interact click-at <X> <Y>`
+
+**Input (CLI args):**
+```
+agentchrome interact click-at <X> <Y> [--double] [--right] [--hold KEY]... [--relative-to TARGET] [--include-snapshot]
+```
 
 **Output (JSON):**
 ```json
@@ -322,6 +362,35 @@ Input.dispatchMouseEvent(s)
 Build + output result
 ```
 
+### Held-Key State
+
+Held keys are command-scoped and never persisted. `--hold` accepts the same key-name inventory as `interact key`, but the click path treats those names as held-key state rather than as a full keypress. For printable keys, keyDown/keyUp events are dispatched without the `text` field so holding `a` while clicking does not type into a focused input as a side effect.
+
+```rust
+/// A validated held key for click/click-at.
+struct HeldKey {
+    name: String,
+    key: String,
+    code: String,
+    windows_virtual_key_code: u32,
+    modifier_bit: Option<u8>,
+}
+```
+
+Held-key execution:
+
+```
+validate held keys (before session setup)
+    ↓
+press held keys in declaration order
+    ↓
+dispatch click with mouse modifiers bitmask derived from held modifier keys
+    ↓
+release held keys in reverse order, including cleanup after click errors
+```
+
+Only the real modifier keys (`Alt`, `Control`, `Meta`, `Shift`) contribute to the CDP mouse `modifiers` field. Other held keys are represented by keyDown/keyUp events around the click.
+
 ---
 
 ## UI Components
@@ -337,6 +406,8 @@ N/A — this is a CLI tool, no UI components.
 | **A: JavaScript-based clicking** | Use `Runtime.evaluate` to call `element.click()` in page context | Simple, no coordinate math | Doesn't simulate real mouse events (no hover, no coordinates, may not trigger all event listeners) | Rejected — not a real mouse simulation |
 | **B: CDP Input.dispatchMouseEvent** | Low-level mouse event dispatch with computed coordinates | Full fidelity, matches real user interaction, works with all event listeners | Requires coordinate computation (getBoxModel), scroll management | **Selected** — matches MCP server approach |
 | **C: CDP DOM.focus + synthetic events** | Focus element then fire synthetic click | Simpler than Input dispatch | Missing coordinate info, doesn't trigger pointer events | Rejected — incomplete simulation |
+| **D: Mouse modifiers only** | Add the CDP `modifiers` bitmask to click payloads without keyDown/keyUp events | Minimal CDP traffic and simple implementation | Only supports Alt/Control/Meta/Shift and does not model game-style held keys such as Space | Rejected for issue #291 — user intent is key-hold plus click |
+| **E: Held-key wrapper around click dispatch** | Press any valid key, dispatch the click with matching modifier bitmask, then release keys | Supports arbitrary held keys and preserves DOM modifier booleans for true modifiers | Requires cleanup on click errors and extra CDP events | **Selected for issue #291** |
 
 **Design Decision**: Use `Input.dispatchMouseEvent` with coordinates computed from `DOM.getBoxModel`. This matches how the MCP server implements these tools and provides full-fidelity mouse simulation including hover effects, pointer events, and coordinate-dependent handlers. Elements are scrolled into view with `DOM.scrollIntoViewIfNeeded` before coordinate computation.
 
@@ -370,6 +441,9 @@ N/A — this is a CLI tool, no UI components.
 | Plain Text Formatting | Unit | Plain text output for all result types |
 | CLI Args | Unit | Clap parsing for interact subcommands |
 | Feature | BDD (cucumber-rs) | All 22 acceptance criteria from requirements.md |
+| Held-Key Helpers | Unit | Key validation, duplicate detection, modifier-bitmask calculation, press/release ordering |
+| Held-Key Clicks | BDD + fixture | Shift+click, arbitrary held key + coordinate click, invalid/duplicate held keys, and no-regression unheld clicks |
+| Manual Smoke | Headless Chrome | Purpose-built fixture confirms keydown → click → keyup order and DOM modifier booleans |
 
 ---
 
@@ -382,6 +456,9 @@ N/A — this is a CLI tool, no UI components.
 | Stale snapshot UIDs (page changed since snapshot) | Medium | Medium | `DOM.describeNode` will fail if backendNodeId is invalid — return clear error suggesting re-snapshot |
 | Navigation detection false positives | Low | Low | Only check for `Page.frameNavigated` on main frame, ignore subframe navigations |
 | Drag doesn't work on all pages | Medium | Low | Some drag implementations require specific HTML5 drag events; CDP `Input.dispatchMouseEvent` may not trigger all of them. Document this limitation. |
+| Held keys remain down after click dispatch fails | Low | High | Wrap click dispatch so keyup cleanup runs in reverse order before returning the original error |
+| Printable held keys type into focused inputs | Medium | Medium | Omit `text` from held-key keyDown events; this models key state without synthesizing text input |
+| Validation happens after browser session setup | Low | Medium | Validate invalid and duplicate held keys before opening or using a Chrome session |
 
 ---
 
@@ -396,6 +473,7 @@ N/A — this is a CLI tool, no UI components.
 | Issue | Date | Summary |
 |-------|------|---------|
 | #14 | 2026-02-13 | Initial feature spec |
+| #291 | 2026-05-26 | Added held-key click design for click and click-at commands |
 
 ## Validation Checklist
 

--- a/specs/feature-mouse-interactions/feature.gherkin
+++ b/specs/feature-mouse-interactions/feature.gherkin
@@ -163,3 +163,40 @@ Feature: Mouse Interactions
     Given the page has draggable elements with UIDs "s1" and "s2"
     When I run "agentchrome interact drag s1 s2 --plain"
     Then the output should be plain text "Dragged s1 to s2"
+
+  # Added by issue #291
+  Scenario: Hold Shift while clicking an element
+    Given a connected browser session is on the click held-keys fixture
+    And the fixture has a clickable element with snapshot UID "s1"
+    When I run "agentchrome interact click s1 --hold Shift"
+    Then the fixture should record "Shift" keydown before the click
+    And the click event should have "shiftKey" equal to true
+    And the fixture should record "Shift" keyup after the click
+    And the output JSON should contain "clicked" equal to "s1"
+
+  # Added by issue #291
+  Scenario: Hold any supported key during coordinate clicks
+    Given a connected browser session is on the click held-keys fixture
+    When I run "agentchrome interact click-at 100 200 --hold Space --hold Alt"
+    Then the fixture should record "Space" and "Alt" keydown events before the click
+    And the click event should have "altKey" equal to true
+    And the fixture should record "Alt" and "Space" keyup events after the click
+    And the output JSON should contain "clicked_at.x" equal to 100
+    And the output JSON should contain "clicked_at.y" equal to 200
+
+  # Added by issue #291
+  Scenario: Existing click behavior is preserved without held keys
+    Given a connected browser session is on the click held-keys fixture
+    And the fixture has a clickable element with snapshot UID "s1"
+    When I run "agentchrome interact click s1"
+    Then the output JSON should contain "clicked" equal to "s1"
+    And the output JSON should contain "navigated" equal to false
+    And the fixture should record no held key events for the click
+
+  # Added by issue #291
+  Scenario: Invalid or duplicate held keys are rejected before browser dispatch
+    Given a connected browser session is on the click held-keys fixture
+    When I run "agentchrome interact click s1 --hold Space --hold Space"
+    Then the exit code should be nonzero
+    And stderr should contain "Duplicate"
+    And the fixture should record no click event

--- a/specs/feature-mouse-interactions/requirements.md
+++ b/specs/feature-mouse-interactions/requirements.md
@@ -1,7 +1,7 @@
 # Requirements: Mouse Interactions
 
-**Issues**: #14
-**Date**: 2026-02-13
+**Issues**: #14, #291
+**Date**: 2026-05-26
 **Status**: Draft
 **Author**: Claude (writing-specs)
 
@@ -194,6 +194,35 @@ Targets are identified either by accessibility UID (from `page snapshot`, e.g., 
 **When** I run `agentchrome interact drag s1 s2 --plain`
 **Then** plain text output is returned (e.g., `Dragged s1 to s2`)
 
+### AC23: Hold Shift while clicking an element
+
+**Given** a connected browser session is on a page that records held keys and click event modifier state
+**When** I run `agentchrome interact click s1 --hold Shift`
+**Then** the page observes the click event with `shiftKey` set to `true`
+**And** the page records `Shift` as held during the click
+**And** the AgentChrome command exits successfully with the existing structured click output shape preserved
+
+### AC24: Hold any supported key during coordinate clicks
+
+**Given** a connected browser session is on a page that records keydown, click, and keyup event order at viewport coordinates
+**When** I run `agentchrome interact click-at 100 200 --hold Space --hold Alt`
+**Then** the page records `Space` and `Alt` keydown events before the click
+**And** the click event observes `altKey` set to `true`
+**And** the page records matching keyup events after the click
+
+### AC25: Existing click behavior is preserved when held keys are omitted
+
+**Given** a connected browser session is on a page with normal clickable elements
+**When** I run `agentchrome interact click`, `agentchrome interact click-at`, right-click, double-click, `--wait-until`, and `--include-snapshot` flows without held-key flags
+**Then** their existing output fields, navigation waiting behavior, button behavior, and snapshot behavior remain compatible
+
+### AC26: Invalid or duplicate held keys are rejected
+
+**Given** a user provides an unsupported key name or repeats the same held key on a click command
+**When** AgentChrome parses the command
+**Then** it exits nonzero with a structured validation error
+**And** no browser mouse event is dispatched
+
 ### Generated Gherkin Preview
 
 ```gherkin
@@ -326,6 +355,12 @@ Feature: Mouse Interactions
 | FR10 | Wait for navigation after click if navigation occurs | Must | Similar to navigate command |
 | FR11 | Wait for DOM stability after interactions | Should | Similar to MCP's WaitForHelper |
 | FR12 | JSON, pretty-JSON, and plain text output formats | Must | Consistent with all other commands |
+| FR13 | `--hold <KEY>` on `interact click` — hold any valid AgentChrome key while dispatching an element-targeted click | Must | Reuses the key-name inventory from `interact key` |
+| FR14 | `--hold <KEY>` on `interact click-at` — hold one or more distinct keys while dispatching coordinate clicks, including `--relative-to` coordinates | Must | Multiple `--hold` flags may be supplied |
+| FR15 | Held modifier keys (`Alt`, `Control`, `Meta`, `Shift`) set the matching CDP mouse `modifiers` bitmask during click dispatch | Must | Ensures DOM click handlers observe `altKey`, `ctrlKey`, `metaKey`, and `shiftKey` |
+| FR16 | Invalid or duplicate held-key values fail during argument validation before any browser dispatch | Must | Preserve structured stderr and typed exit-code behavior |
+| FR17 | Existing click/click-at behavior, output fields, wait behavior, and snapshot behavior remain backward-compatible when held keys are omitted | Must | No new output field is required for unmodified clicks |
+| FR18 | Clap help, built-in examples, and BDD coverage document and exercise at least one `--hold <KEY>` click invocation | Should | Supports agent discovery through help, examples, and tests |
 
 ---
 
@@ -370,6 +405,7 @@ Reference `structure.md` and `product.md` for project-specific design standards.
 | --right | Boolean flag | N/A | No |
 | --include-snapshot | Boolean flag | N/A | No |
 | --tab | String | Valid tab ID or index | No (defaults to active tab) |
+| --hold | Repeatable key-name flag | Any key accepted by `interact key`; no duplicates | No |
 
 ### Output Data — `interact click`
 
@@ -433,6 +469,8 @@ Reference `structure.md` and `product.md` for project-specific design standards.
 - Form filling (select dropdown, toggle checkbox) — separate issue (#15)
 - Mouse move without hover semantics (raw `Input.dispatchMouseEvent` with `mouseMoved`)
 - Multi-step interaction sequences (click + wait + click) — users compose commands in scripts
+- Held-key support for drag, mousedown-at, and mouseup-at unless required internally to satisfy modified click behavior
+- Browser-game-specific automation heuristics or gameplay logic
 
 ---
 
@@ -458,6 +496,7 @@ Reference `structure.md` and `product.md` for project-specific design standards.
 | Issue | Date | Summary |
 |-------|------|---------|
 | #14 | 2026-02-13 | Initial feature spec |
+| #291 | 2026-05-26 | Added held-key support for click and click-at commands |
 
 ## Validation Checklist
 

--- a/specs/feature-mouse-interactions/tasks.md
+++ b/specs/feature-mouse-interactions/tasks.md
@@ -1,8 +1,8 @@
 # Tasks: Mouse Interactions
 
-**Issues**: #14
-**Date**: 2026-02-13
-**Status**: Planning
+**Issues**: #14, #291
+**Date**: 2026-05-26
+**Status**: Implementation complete for #291
 **Author**: Claude (writing-specs)
 
 ---
@@ -15,7 +15,8 @@
 | Backend | 4 | [ ] |
 | Integration | 1 | [ ] |
 | Testing | 2 | [ ] |
-| **Total** | **9** | |
+| Enhancement #291 | 8 | [x] |
+| **Total** | **17** | |
 
 ---
 
@@ -294,6 +295,113 @@ Map `{layer}/` placeholders to actual project paths using `structure.md`.
 
 ---
 
+## Phase 5: Enhancement — Issue #291 Held-Key Clicks
+
+### T012: Add held-key CLI args and help examples
+
+**File(s)**: `src/cli/mod.rs`
+**Type**: Modify
+**Depends**: None
+**Acceptance**:
+- [x] `ClickArgs` includes a repeatable `--hold <KEY>` argument for held keys
+- [x] `ClickAtArgs` includes a repeatable `--hold <KEY>` argument for held keys
+- [x] The held-key argument documents that values use the same key names as `interact key`
+- [x] `interact click --help` includes at least one worked `--hold` example
+- [x] `interact click-at --help` includes at least one worked `--hold` example
+- [x] Existing `--double`, `--right`, `--wait-until`, `--relative-to`, `--compact`, and `--include-snapshot` help remains present
+
+**Notes**: Prefer a canonical `--hold <KEY>` surface because issue #291 requires arbitrary held keys, not only the four DOM modifier keys.
+
+### T013: Add held-key validation and metadata helpers
+
+**File(s)**: `src/interact.rs`
+**Type**: Modify
+**Depends**: T012
+**Acceptance**:
+- [x] Held-key validation accepts any key currently accepted by `interact key`
+- [x] Duplicate held keys return a structured validation error before session setup
+- [x] Invalid held keys return a structured validation error before session setup
+- [x] Helper computes the CDP mouse modifier bitmask from held `Alt`, `Control`, `Meta`, and `Shift`
+- [x] Unit tests cover valid arbitrary keys, real modifier keys, duplicate keys, invalid keys, and bitmask calculation
+
+### T014: Wrap click dispatch in keyDown/click/keyUp lifecycle
+
+**File(s)**: `src/interact.rs`
+**Type**: Modify
+**Depends**: T013
+**Acceptance**:
+- [x] `execute_click` validates held keys before opening or using a browser session
+- [x] `execute_click_at` validates held keys before opening or using a browser session
+- [x] Held keys are pressed in declaration order before the click dispatch
+- [x] Click dispatch includes the derived mouse `modifiers` bitmask on every `mousePressed` and `mouseReleased` payload, including double-click payloads
+- [x] Held keys are released in reverse order after click dispatch
+- [x] Held keys are released in reverse order when click dispatch returns an error, and the original click error remains visible
+- [x] Printable held keys do not synthesize text input as a side effect of the hold
+- [x] Existing unheld click and click-at behavior remains unchanged
+
+### T015: Add built-in examples for held-key clicks
+
+**File(s)**: `src/examples_data.rs`
+**Type**: Modify
+**Depends**: T012
+**Acceptance**:
+- [x] `agentchrome examples interact` includes an element-targeted held-key click example
+- [x] `agentchrome examples interact` includes a coordinate held-key click example or equivalent note
+- [x] Example text uses the canonical `--hold <KEY>` flag
+- [x] Existing interact examples remain intact
+
+### T016: Create deterministic held-click fixture
+
+**File(s)**: `tests/fixtures/click-held-keys.html`
+**Type**: Create
+**Depends**: None
+**Acceptance**:
+- [x] Fixture records keydown events, click event modifier fields, and keyup events in order
+- [x] Fixture exposes a clickable element targetable by both UID/snapshot and CSS selector
+- [x] Fixture exposes a coordinate-click target area
+- [x] Fixture provides an inspectable result element or script state that BDD steps can query with AgentChrome
+- [x] Fixture is deterministic and uses no network dependencies
+
+### T017: Append issue #291 BDD scenarios
+
+**File(s)**: `tests/features/interact.feature`, `specs/feature-mouse-interactions/feature.gherkin`
+**Type**: Modify
+**Depends**: T016
+**Acceptance**:
+- [x] Scenario for `interact click <target> --hold Shift` verifies `shiftKey` and held-key event order
+- [x] Scenario for `interact click-at <x> <y> --hold Space --hold Alt` verifies arbitrary key hold, `altKey`, and keyup cleanup
+- [x] Scenario for unheld click/click-at regression verifies existing output behavior remains compatible
+- [x] Scenario for invalid or duplicate held keys verifies nonzero structured error and no browser event
+- [x] Scenarios are marked or documented as added by issue #291
+
+### T018: Wire BDD and unit tests
+
+**File(s)**: `tests/bdd.rs`, `src/interact.rs`
+**Type**: Modify
+**Depends**: T013, T014, T017
+**Acceptance**:
+- [x] BDD harness can load `tests/fixtures/click-held-keys.html`
+- [x] BDD steps can assert recorded keydown/click/keyup order from the fixture
+- [x] BDD steps can assert DOM click modifier booleans for real modifier keys
+- [x] BDD steps verify invalid or duplicate held-key commands do not mutate fixture state
+- [x] Unit tests cover held-key helper behavior without Chrome
+
+### T019: Verify held-key click behavior
+
+**File(s)**: `specs/feature-mouse-interactions/verification-report.md`
+**Type**: Create
+**Depends**: T014, T015, T018
+**Acceptance**:
+- [x] `cargo build` passes
+- [x] `cargo test --lib` passes
+- [x] Focused BDD scenarios for issue #291 pass or are documented with an explicit environment reason
+- [x] `cargo fmt --check` passes
+- [x] `cargo clippy --all-targets` passes
+- [x] Manual headless Chrome smoke test exercises the fixture with `--hold Shift` and `--hold Space --hold Alt`
+- [x] Verification report records every acceptance criterion result and any residual risk
+
+---
+
 ## Dependency Graph
 
 ```
@@ -311,6 +419,13 @@ T002 (errors) ────┘                                          │
                                                               │
                                                               ▼
                                                     T009 (step defs + unit tests)
+
+Issue #291:
+T012 (held-key CLI args)
+  ├──▶ T013 (held-key helpers) ──▶ T014 (keyDown/click/keyUp lifecycle) ──┬──▶ T018 (BDD/unit wiring) ──▶ T019 (verification)
+  │                                                                       │
+  └──▶ T015 (examples)                                                    │
+T016 (fixture) ──▶ T017 (BDD scenarios) ──────────────────────────────────┘
 ```
 
 ---
@@ -320,6 +435,7 @@ T002 (errors) ────┘                                          │
 | Issue | Date | Summary |
 |-------|------|---------|
 | #14 | 2026-02-13 | Initial feature spec |
+| #291 | 2026-05-26 | Added held-key click implementation plan |
 
 ## Validation Checklist
 

--- a/specs/feature-mouse-interactions/verification-report.md
+++ b/specs/feature-mouse-interactions/verification-report.md
@@ -1,0 +1,38 @@
+# Verification Report: Feature Mouse Interactions
+
+**Issue**: #291
+**Date**: 2026-05-26
+**Status**: Implementation verified
+
+## Summary
+
+Held-key click support was implemented for `interact click` and `interact click-at` with repeatable `--hold <KEY>` flags. Held keys are validated before session setup, pressed before click dispatch, represented in mouse modifier bitmasks for real modifiers, and released in reverse order after dispatch.
+
+## Automated Checks
+
+| Check | Result |
+| --- | --- |
+| `cargo build` | Pass |
+| `cargo test --lib duplicate_held_key_error` | Pass |
+| `cargo test --bin agentchrome validate_held_keys` | Pass |
+| `cargo test --bin agentchrome mouse_buttons_bitfield_matches_cdp_values` | Pass |
+| `cargo test --bin agentchrome` | Pass, 805 tests |
+| `cargo test --test bdd` | Pass |
+| `cargo fmt --check` | Pass |
+| `cargo clippy --all-targets -- -D warnings` | Pass |
+
+## Manual Smoke
+
+Fixture: `tests/fixtures/click-held-keys.html`
+
+| Command | Result |
+| --- | --- |
+| `agentchrome interact click s1 --hold Shift` | Pass: event log recorded keydown Shift, click on target with `shiftKey: true`, keyup Shift |
+| `agentchrome interact click-at 100 200 --hold Space --hold Alt` | Pass: event log recorded keydown Space, keydown Alt, click on pad with `altKey: true`, keyup Alt, keyup Space |
+| `agentchrome connect --disconnect` then `agentchrome connect --status` | Pass: launched Chrome was disconnected and status returned `active: false` |
+
+## Residual Risk
+
+The live held-key scenarios are documented in `tests/features/interact.feature` and have BDD step bindings, but the default no-Chrome `interact.feature` filter still only executes CLI-validation scenarios. Live fixture behavior was also verified manually with AgentChrome.
+
+Control-click was intentionally not used for the coordinate smoke scenario because macOS Chrome treats Control-left-click as a context-menu gesture and may suppress the DOM `click` event. The implementation still accepts `Control` and includes it in the modifier bitmask.

--- a/specs/feature-mouse-interactions/verification-report.md
+++ b/specs/feature-mouse-interactions/verification-report.md
@@ -1,38 +1,92 @@
 # Verification Report: Feature Mouse Interactions
 
 **Issue**: #291
-**Date**: 2026-05-26
-**Status**: Implementation verified
+**Date**: 2026-06-11
+**Implementation Status**: Pass
 
-## Summary
+## Executive Summary
 
-Held-key click support was implemented for `interact click` and `interact click-at` with repeatable `--hold <KEY>` flags. Held keys are validated before session setup, pressed before click dispatch, represented in mouse modifier bitmasks for real modifiers, and released in reverse order after dispatch.
+Held-key click support for issue #291 is verified. `interact click` and `interact click-at` accept repeatable `--hold <KEY>` arguments, validate invalid and duplicate held keys before browser dispatch, press keys before click dispatch, send real modifier bits for `Alt`, `Control`, `Meta`, and `Shift`, and release held keys after dispatch.
 
-## Automated Checks
+The implementation satisfies the issue intent for modifier-sensitive clicks through the canonical spec surface `--hold <KEY>`. The original issue used `--modifier`; the active spec deliberately broadened the surface to any key accepted by `interact key`, while still covering modifier-click use cases.
 
-| Check | Result |
-| --- | --- |
-| `cargo build` | Pass |
-| `cargo test --lib duplicate_held_key_error` | Pass |
-| `cargo test --bin agentchrome validate_held_keys` | Pass |
-| `cargo test --bin agentchrome mouse_buttons_bitfield_matches_cdp_values` | Pass |
-| `cargo test --bin agentchrome` | Pass, 805 tests |
-| `cargo test --test bdd` | Pass |
-| `cargo fmt --check` | Pass |
-| `cargo clippy --all-targets -- -D warnings` | Pass |
+## Acceptance Criteria
 
-## Manual Smoke
+- [x] AC23: Hold Shift while clicking an element - implemented in `src/cli/mod.rs`, `src/interact.rs`, `tests/features/interact.feature`, and `tests/fixtures/click-held-keys.html`.
+- [x] AC24: Hold any supported key during coordinate clicks - implemented in `src/cli/mod.rs`, `src/interact.rs`, `tests/features/interact.feature`, and `tests/fixtures/click-held-keys.html`.
+- [x] AC25: Existing click behavior is preserved when held keys are omitted - verified by existing BDD coverage plus live unheld fixture smoke.
+- [x] AC26: Invalid or duplicate held keys are rejected - implemented in `src/interact.rs` and `src/error.rs`, with unit and BDD coverage.
+
+## Task Verification
+
+| Task | Status | Evidence |
+|------|--------|----------|
+| T012: Add held-key CLI args and help examples | Complete | `ClickArgs` and `ClickAtArgs` expose repeatable `--hold <KEY>` and help/man pages include held-click examples. |
+| T013: Add held-key validation and metadata helpers | Complete | `validate_held_keys`, `held_key_modifier_mask`, and duplicate/invalid error constructors are present and covered by unit tests. |
+| T014: Wrap click dispatch in keyDown/click/keyUp lifecycle | Complete | `dispatch_click_with_held_keys` presses, clicks, and releases in the required order, including cleanup after click errors. |
+| T015: Add built-in examples for held-key clicks | Complete | `examples interact` includes element and coordinate held-key examples. |
+| T016: Create deterministic held-click fixture | Complete | `tests/fixtures/click-held-keys.html` records keydown, click, keyup, targets, and modifier booleans. |
+| T017: Append issue #291 BDD scenarios | Complete | `tests/features/interact.feature` includes Shift-click, Space+Alt click-at, unheld regression, and validation scenarios. |
+| T018: Wire BDD and unit tests | Complete | `tests/bdd.rs` has fixture loading, event-log assertions, structured-output checks, and validation bindings. |
+| T019: Verify held-key click behavior | Complete | Verification gates and live headless smoke passed on this checkout. |
+
+## Architecture Review
+
+| Area | Score (1-5) | Notes |
+|------|-------------|-------|
+| SOLID Principles | 4.6 | CLI parsing stays in `src/cli/mod.rs`; held-key validation and dispatch behavior stay in `src/interact.rs`; errors remain centralized in `src/error.rs`. |
+| Security | 4.8 | No new external services, secrets, telemetry, or shell execution; CDP interaction remains local to the existing AgentChrome session model. |
+| Performance | 4.6 | Held-key processing is bounded by a short CLI arg list and adds only the required CDP key events around clicks. |
+| Testability | 4.5 | Pure helper unit tests, BDD scenarios, deterministic fixture, and live smoke cover the new behavior. Default BDD filters still keep Chrome-dependent held-key scenarios out of the no-Chrome subset, so live smoke remains part of verification. |
+| Error Handling | 4.7 | Invalid and duplicate held keys produce structured JSON errors before browser dispatch; click errors preserve original failures while best-effort key release cleanup runs. |
+
+Average architecture score: 4.6
+
+## Test Coverage
+
+- BDD scenarios: 4/4 issue #291 acceptance criteria covered in feature files.
+- Step definitions: Implemented for held-key fixture setup, command execution, event-log assertions, and validation errors.
+- Test execution: Pass.
+- Unit coverage: Held-key validation, duplicate error construction, and mouse bitfield behavior are covered.
+- Manual live coverage: Pass against `tests/fixtures/click-held-keys.html`.
+
+## Steering Doc Verification Gates
+
+| Gate | Status | Evidence |
+|------|--------|----------|
+| Debug Build | Pass | `cargo build 2>&1` exited 0. |
+| Unit Tests | Pass | `cargo test --lib 2>&1` exited 0 with 257 passed. |
+| Clippy | Pass | `cargo clippy --all-targets 2>&1` exited 0 after moving the BDD tolerance constant before statements. |
+| Format Check | Pass | `cargo fmt --check 2>&1` exited 0. |
+| Feature Exercise | Pass | Headless AgentChrome smoke verified `click s1 --hold Shift`, `click-at 100 200 --hold Space --hold Alt`, duplicate and invalid held-key errors, unheld click regression, and disconnect cleanup. |
+
+**Gate Summary**: 5/5 passed, 0 failed, 0 incomplete.
+
+## Feature Exercise Evidence
 
 Fixture: `tests/fixtures/click-held-keys.html`
 
 | Command | Result |
-| --- | --- |
-| `agentchrome interact click s1 --hold Shift` | Pass: event log recorded keydown Shift, click on target with `shiftKey: true`, keyup Shift |
-| `agentchrome interact click-at 100 200 --hold Space --hold Alt` | Pass: event log recorded keydown Space, keydown Alt, click on pad with `altKey: true`, keyup Alt, keyup Space |
-| `agentchrome connect --disconnect` then `agentchrome connect --status` | Pass: launched Chrome was disconnected and status returned `active: false` |
+|---------|--------|
+| `./target/debug/agentchrome connect --launch --headless` | Pass: launched managed Chrome on local CDP port. |
+| `./target/debug/agentchrome page snapshot --compact` | Pass: fixture exposed `s1` as the target button and `s2` as the coordinate pad. |
+| `./target/debug/agentchrome interact click s1 --hold Shift` | Pass: event log recorded keydown `Shift`, click target `target` with `shiftKey: true`, then keyup `Shift`. |
+| `./target/debug/agentchrome interact click-at 100 200 --hold Space --hold Alt` | Pass: event log recorded keydown Space, keydown Alt, click target `pad` with `altKey: true`, then keyup Alt and Space. |
+| `./target/debug/agentchrome interact click s1 --hold Space --hold Space` | Pass: exited 1 with `{"error":"Duplicate held key: 'Space'","code":1}`. |
+| `./target/debug/agentchrome interact click s1 --hold DefinitelyNotAKey` | Pass: exited 1 with `{"error":"Invalid key: 'DefinitelyNotAKey'","code":1}`. |
+| `./target/debug/agentchrome interact click s1` | Pass: output shape remained `{"clicked":"s1","navigated":false,"url":"..."}` and event log recorded only an unmodified click. |
+| `./target/debug/agentchrome connect --disconnect` and `connect --status` | Pass: managed Chrome was killed and status returned `{"active":false}`. |
 
-## Residual Risk
+## Fixes Applied
 
-The live held-key scenarios are documented in `tests/features/interact.feature` and have BDD step bindings, but the default no-Chrome `interact.feature` filter still only executes CLI-validation scenarios. Live fixture behavior was also verified manually with AgentChrome.
+| Severity | Category | Location | Issue | Fix | Routing |
+|----------|----------|----------|-------|-----|---------|
+| Minor | Clippy | `tests/bdd.rs` | `clippy::items-after-statements` warned because the float comparison tolerance constant appeared after statements. | Moved the constant to the start of `output_json_number_field_equals`. | direct |
 
-Control-click was intentionally not used for the coordinate smoke scenario because macOS Chrome treats Control-left-click as a context-menu gesture and may suppress the DOM `click` event. The implementation still accepts `Control` and includes it in the modifier bitmask.
+## Remaining Issues
+
+None.
+
+## Recommendations
+
+Ready for PR. Control-click was not used for the coordinate smoke because macOS Chrome may treat Control-left-click as a context-menu gesture and suppress the DOM `click`; the implementation still accepts `Control` and maps it into the CDP modifier bitmask.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2327,7 +2327,8 @@ pub enum InteractCommand {
         long_about = "Click an element identified by UID (from 'page snapshot', e.g., 's5') or \
             CSS selector (prefixed with 'css:', e.g., 'css:#submit'). By default, performs a \
             left single-click at the element's center. Use --double for double-click or --right \
-            for right-click (context menu). These flags are mutually exclusive.",
+            for right-click (context menu). These flags are mutually exclusive. Use --hold to \
+            hold one or more keys while dispatching the click.",
         after_long_help = "\
 EXAMPLES:
   # Click by UID
@@ -2340,7 +2341,10 @@ EXAMPLES:
   agentchrome interact click s5 --double
 
   # Right-click (context menu)
-  agentchrome interact click s5 --right"
+  agentchrome interact click s5 --right
+
+  # Shift-click an element
+  agentchrome interact click s5 --hold Shift"
     )]
     Click(ClickArgs),
 
@@ -2348,14 +2352,18 @@ EXAMPLES:
     #[command(
         long_about = "Click at specific viewport coordinates (X, Y in pixels). Useful when \
             targeting elements that are not in the accessibility tree or for precise coordinate-\
-            based interactions. Use --double for double-click or --right for right-click.",
+            based interactions. Use --double for double-click or --right for right-click. Use \
+            --hold to hold one or more keys while dispatching the click.",
         after_long_help = "\
 EXAMPLES:
   # Click at coordinates
   agentchrome interact click-at 100 200
 
   # Double-click at coordinates
-  agentchrome interact click-at 100 200 --double"
+  agentchrome interact click-at 100 200 --double
+
+  # Hold Space and Alt while clicking coordinates
+  agentchrome interact click-at 100 200 --hold Space --hold Alt"
     )]
     ClickAt(ClickAtArgs),
 
@@ -2534,6 +2542,11 @@ pub struct ClickArgs {
     #[arg(long, conflicts_with = "double")]
     pub right: bool,
 
+    /// Hold a key while dispatching the click. Uses the same key names as `interact key`.
+    /// Can be repeated.
+    #[arg(long = "hold", value_name = "KEY")]
+    pub hold: Vec<String>,
+
     /// Include updated accessibility snapshot in output
     #[arg(long)]
     pub include_snapshot: bool,
@@ -2572,6 +2585,11 @@ pub struct ClickAtArgs {
     /// Perform a right-click (context menu) instead of left click (conflicts with --double)
     #[arg(long, conflicts_with = "double")]
     pub right: bool,
+
+    /// Hold a key while dispatching the click. Uses the same key names as `interact key`.
+    /// Can be repeated.
+    #[arg(long = "hold", value_name = "KEY")]
+    pub hold: Vec<String>,
 
     /// Include updated accessibility snapshot in output
     #[arg(long)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -394,6 +394,15 @@ impl AppError {
     }
 
     #[must_use]
+    pub fn duplicate_held_key(key: &str) -> Self {
+        Self {
+            message: format!("Duplicate held key: '{key}'"),
+            code: ExitCode::GeneralError,
+            custom_json: None,
+        }
+    }
+
+    #[must_use]
     pub fn interaction_failed(action: &str, reason: &str) -> Self {
         Self {
             message: format!("Interaction failed ({action}): {reason}"),
@@ -943,6 +952,14 @@ mod tests {
         let err = AppError::duplicate_modifier("Control");
         assert!(err.message.contains("Duplicate modifier"));
         assert!(err.message.contains("Control"));
+        assert!(matches!(err.code, ExitCode::GeneralError));
+    }
+
+    #[test]
+    fn duplicate_held_key_error() {
+        let err = AppError::duplicate_held_key("Space");
+        assert!(err.message.contains("Duplicate held key"));
+        assert!(err.message.contains("Space"));
         assert!(matches!(err.code, ExitCode::GeneralError));
     }
 

--- a/src/examples_data.rs
+++ b/src/examples_data.rs
@@ -474,6 +474,16 @@ pub fn all_examples() -> Vec<CommandGroupSummary> {
                     flags: Some(vec!["--wait-until".into()]),
                 },
                 ExampleEntry {
+                    cmd: "agentchrome interact click s5 --hold Shift".into(),
+                    description: "Hold Shift while clicking an element".into(),
+                    flags: Some(vec!["--hold".into()]),
+                },
+                ExampleEntry {
+                    cmd: "agentchrome interact click-at 100 200 --hold Space --hold Alt".into(),
+                    description: "Hold multiple keys while clicking coordinates".into(),
+                    flags: Some(vec!["--hold".into()]),
+                },
+                ExampleEntry {
                     cmd: "agentchrome interact type \"Hello, world!\"".into(),
                     description: "Type text into the focused element".into(),
                     flags: None,

--- a/src/interact.rs
+++ b/src/interact.rs
@@ -397,6 +397,7 @@ async fn dispatch_click(
     y: f64,
     button: &str,
     click_count: u8,
+    modifiers: u8,
     mut dialog_open_rx: Option<&mut mpsc::Receiver<CdpEvent>>,
 ) -> Result<bool, AppError> {
     let mut opened_dialog = false;
@@ -409,7 +410,9 @@ async fn dispatch_click(
             "x": x,
             "y": y,
             "button": button,
+            "buttons": mouse_buttons_bitfield(button),
             "clickCount": 1,
+            "modifiers": modifiers,
         });
         opened_dialog |= dispatch_mouse_event(
             session,
@@ -424,7 +427,9 @@ async fn dispatch_click(
             "x": x,
             "y": y,
             "button": button,
+            "buttons": 0,
             "clickCount": 1,
+            "modifiers": modifiers,
         });
         opened_dialog |= dispatch_mouse_event(
             session,
@@ -440,7 +445,9 @@ async fn dispatch_click(
             "x": x,
             "y": y,
             "button": button,
+            "buttons": mouse_buttons_bitfield(button),
             "clickCount": 2,
+            "modifiers": modifiers,
         });
         opened_dialog |= dispatch_mouse_event(
             session,
@@ -455,7 +462,9 @@ async fn dispatch_click(
             "x": x,
             "y": y,
             "button": button,
+            "buttons": 0,
             "clickCount": 2,
+            "modifiers": modifiers,
         });
         opened_dialog |= dispatch_mouse_event(
             session,
@@ -471,7 +480,9 @@ async fn dispatch_click(
             "x": x,
             "y": y,
             "button": button,
+            "buttons": mouse_buttons_bitfield(button),
             "clickCount": click_count,
+            "modifiers": modifiers,
         });
         opened_dialog |= dispatch_mouse_event(
             session,
@@ -486,13 +497,24 @@ async fn dispatch_click(
             "x": x,
             "y": y,
             "button": button,
+            "buttons": 0,
             "clickCount": click_count,
+            "modifiers": modifiers,
         });
         opened_dialog |=
             dispatch_mouse_event(session, release_params, "mouse_release", dialog_open_rx).await?;
     }
 
     Ok(opened_dialog)
+}
+
+fn mouse_buttons_bitfield(button: &str) -> u8 {
+    match button {
+        "left" => 1,
+        "right" => 2,
+        "middle" => 4,
+        _ => 0,
+    }
 }
 
 async fn dispatch_mouse_event(
@@ -1249,6 +1271,144 @@ const MODIFIER_MAP: &[(u8, &str, &str)] = &[
     (8, "Shift", "ShiftLeft"),
 ];
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct HeldKey {
+    name: String,
+    key: String,
+    code: String,
+    windows_virtual_key_code: i64,
+    modifier_bit: Option<u8>,
+}
+
+fn modifier_bit_for_key(key: &str) -> Option<u8> {
+    MODIFIER_MAP
+        .iter()
+        .find_map(|(bit, modifier_key, _code)| (*modifier_key == key).then_some(*bit))
+}
+
+fn validate_held_keys(keys: &[String]) -> Result<Vec<HeldKey>, AppError> {
+    let mut held_keys = Vec::with_capacity(keys.len());
+
+    for key in keys {
+        if !is_valid_key(key) {
+            return Err(AppError::invalid_key(key));
+        }
+        if held_keys
+            .iter()
+            .any(|held_key: &HeldKey| held_key.name == *key)
+        {
+            return Err(AppError::duplicate_held_key(key));
+        }
+
+        held_keys.push(HeldKey {
+            name: key.clone(),
+            key: cdp_key_value(key).to_string(),
+            code: cdp_key_code(key),
+            windows_virtual_key_code: windows_virtual_key_code(key),
+            modifier_bit: modifier_bit_for_key(key),
+        });
+    }
+
+    Ok(held_keys)
+}
+
+fn held_key_modifier_mask(held_keys: &[HeldKey]) -> u8 {
+    held_keys
+        .iter()
+        .filter_map(|held_key| held_key.modifier_bit)
+        .fold(0, |mask, bit| mask | bit)
+}
+
+async fn dispatch_held_key_event(
+    session: &mut ManagedSession,
+    event_type: &str,
+    held_key: &HeldKey,
+    modifiers: u8,
+) -> Result<(), AppError> {
+    let params = serde_json::json!({
+        "type": event_type,
+        "key": held_key.key,
+        "code": held_key.code,
+        "modifiers": modifiers,
+        "windowsVirtualKeyCode": held_key.windows_virtual_key_code,
+    });
+    let action = if event_type == "keyDown" {
+        "held_key_down"
+    } else {
+        "held_key_up"
+    };
+    session
+        .send_command("Input.dispatchKeyEvent", Some(params))
+        .await
+        .map_err(|e| AppError::interaction_failed(action, &e.to_string()))?;
+    Ok(())
+}
+
+async fn press_held_keys(
+    session: &mut ManagedSession,
+    held_keys: &[HeldKey],
+) -> Result<u8, AppError> {
+    let mut active_modifiers = 0;
+
+    for held_key in held_keys {
+        if let Some(bit) = held_key.modifier_bit {
+            active_modifiers |= bit;
+        }
+        dispatch_held_key_event(session, "keyDown", held_key, active_modifiers).await?;
+    }
+
+    Ok(active_modifiers)
+}
+
+async fn release_held_keys(
+    session: &mut ManagedSession,
+    held_keys: &[HeldKey],
+    mut active_modifiers: u8,
+) -> Result<(), AppError> {
+    for held_key in held_keys.iter().rev() {
+        if let Some(bit) = held_key.modifier_bit {
+            active_modifiers &= !bit;
+        }
+        dispatch_held_key_event(session, "keyUp", held_key, active_modifiers).await?;
+    }
+
+    Ok(())
+}
+
+async fn dispatch_click_with_held_keys(
+    session: &mut ManagedSession,
+    held_keys: &[HeldKey],
+    x: f64,
+    y: f64,
+    button: &str,
+    click_count: u8,
+    dialog_open_rx: Option<&mut mpsc::Receiver<CdpEvent>>,
+) -> Result<bool, AppError> {
+    if held_keys.is_empty() {
+        return dispatch_click(session, x, y, button, click_count, 0, dialog_open_rx).await;
+    }
+
+    let click_modifiers = held_key_modifier_mask(held_keys);
+    let active_modifiers = press_held_keys(session, held_keys).await?;
+    let click_result = dispatch_click(
+        session,
+        x,
+        y,
+        button,
+        click_count,
+        click_modifiers,
+        dialog_open_rx,
+    )
+    .await;
+    let release_result = release_held_keys(session, held_keys, active_modifiers).await;
+
+    match (click_result, release_result) {
+        (Err(click_error), _) => Err(click_error),
+        (Ok(_), Err(release_error)) => Err(release_error),
+        (Ok(opened_dialog), Ok(())) => Ok(opened_dialog),
+    }
+}
+
 /// Dispatch a key combination: press modifiers, press key, release key, release modifiers.
 async fn dispatch_key_combination(
     session: &mut ManagedSession,
@@ -1774,6 +1934,7 @@ async fn execute_click(
     args: &ClickArgs,
     frame: Option<&str>,
 ) -> Result<(), AppError> {
+    let held_keys = validate_held_keys(&args.hold)?;
     let (client, mut managed) = setup_session_with_interceptors(global).await?;
     let (_dismiss, dialog_settle_rx) = if global.auto_dismiss_dialogs {
         let (handle, rx) = managed.spawn_auto_dismiss_with_settle().await?;
@@ -1821,8 +1982,9 @@ async fn execute_click(
     match args.wait_until {
         Some(WaitUntil::None) => {
             // Dispatch and return immediately — no grace period, no navigation check
-            opened_dialog = dispatch_click(
+            opened_dialog = dispatch_click_with_held_keys(
                 &mut managed,
+                &held_keys,
                 x,
                 y,
                 button,
@@ -1834,8 +1996,9 @@ async fn execute_click(
         }
         Some(WaitUntil::Load) => {
             let wait_rx = managed.subscribe("Page.loadEventFired").await?;
-            opened_dialog = dispatch_click(
+            opened_dialog = dispatch_click_with_held_keys(
                 &mut managed,
+                &held_keys,
                 x,
                 y,
                 button,
@@ -1853,8 +2016,9 @@ async fn execute_click(
         }
         Some(WaitUntil::Domcontentloaded) => {
             let wait_rx = managed.subscribe("Page.domContentEventFired").await?;
-            opened_dialog = dispatch_click(
+            opened_dialog = dispatch_click_with_held_keys(
                 &mut managed,
+                &held_keys,
                 x,
                 y,
                 button,
@@ -1875,8 +2039,9 @@ async fn execute_click(
             let req_rx = managed.subscribe("Network.requestWillBeSent").await?;
             let fin_rx = managed.subscribe("Network.loadingFinished").await?;
             let fail_rx = managed.subscribe("Network.loadingFailed").await?;
-            opened_dialog = dispatch_click(
+            opened_dialog = dispatch_click_with_held_keys(
                 &mut managed,
+                &held_keys,
                 x,
                 y,
                 button,
@@ -1896,8 +2061,9 @@ async fn execute_click(
         None => {
             // Legacy behavior: 100ms grace period with non-blocking navigation check
             let mut nav_rx = managed.subscribe("Page.frameNavigated").await?;
-            opened_dialog = dispatch_click(
+            opened_dialog = dispatch_click_with_held_keys(
                 &mut managed,
+                &held_keys,
                 x,
                 y,
                 button,
@@ -1976,6 +2142,7 @@ async fn execute_click_at(
     args: &ClickAtArgs,
     frame: Option<&str>,
 ) -> Result<(), AppError> {
+    let held_keys = validate_held_keys(&args.hold)?;
     // Validate percentage coordinates before establishing a session so that the error message
     // references --relative-to even when Chrome is not reachable.
     if args.relative_to.is_none() {
@@ -2035,8 +2202,9 @@ async fn execute_click_at(
 
     let (url, navigated) = match args.wait_until {
         Some(WaitUntil::None) => {
-            opened_dialog = dispatch_click(
+            opened_dialog = dispatch_click_with_held_keys(
                 &mut managed,
+                &held_keys,
                 click_x,
                 click_y,
                 button,
@@ -2050,8 +2218,9 @@ async fn execute_click_at(
             managed.ensure_domain("Page").await?;
             let pre_url = get_current_url(&managed).await?;
             let wait_rx = managed.subscribe("Page.loadEventFired").await?;
-            opened_dialog = dispatch_click(
+            opened_dialog = dispatch_click_with_held_keys(
                 &mut managed,
+                &held_keys,
                 click_x,
                 click_y,
                 button,
@@ -2073,8 +2242,9 @@ async fn execute_click_at(
             managed.ensure_domain("Page").await?;
             let pre_url = get_current_url(&managed).await?;
             let wait_rx = managed.subscribe("Page.domContentEventFired").await?;
-            opened_dialog = dispatch_click(
+            opened_dialog = dispatch_click_with_held_keys(
                 &mut managed,
+                &held_keys,
                 click_x,
                 click_y,
                 button,
@@ -2098,8 +2268,9 @@ async fn execute_click_at(
             let req_rx = managed.subscribe("Network.requestWillBeSent").await?;
             let fin_rx = managed.subscribe("Network.loadingFinished").await?;
             let fail_rx = managed.subscribe("Network.loadingFailed").await?;
-            opened_dialog = dispatch_click(
+            opened_dialog = dispatch_click_with_held_keys(
                 &mut managed,
+                &held_keys,
                 click_x,
                 click_y,
                 button,
@@ -2119,8 +2290,9 @@ async fn execute_click_at(
         }
         None => {
             // Legacy behavior: dispatch click, no navigation check
-            opened_dialog = dispatch_click(
+            opened_dialog = dispatch_click_with_held_keys(
                 &mut managed,
+                &held_keys,
                 click_x,
                 click_y,
                 button,
@@ -3013,6 +3185,14 @@ mod tests {
         );
     }
 
+    #[test]
+    fn mouse_buttons_bitfield_matches_cdp_values() {
+        assert_eq!(mouse_buttons_bitfield("left"), 1);
+        assert_eq!(mouse_buttons_bitfield("right"), 2);
+        assert_eq!(mouse_buttons_bitfield("middle"), 4);
+        assert_eq!(mouse_buttons_bitfield("unknown"), 0);
+    }
+
     // =========================================================================
     // Key validation and parsing tests
     // =========================================================================
@@ -3060,6 +3240,41 @@ mod tests {
         let err = parse_key_combination("Control+Control+A").unwrap_err();
         assert!(
             err.message.contains("Duplicate modifier: 'Control'"),
+            "got: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn validate_held_keys_accepts_modifier_and_arbitrary_key() {
+        let held = validate_held_keys(&["Space".to_string(), "Control".to_string()]).unwrap();
+
+        assert_eq!(
+            held.iter()
+                .map(|held_key| held_key.name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["Space", "Control"]
+        );
+        assert_eq!(held_key_modifier_mask(&held), 2);
+    }
+
+    #[test]
+    fn validate_held_keys_rejects_invalid_key() {
+        let err = validate_held_keys(&["FooBar".to_string()]).unwrap_err();
+
+        assert!(
+            err.message.contains("Invalid key: 'FooBar'"),
+            "got: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn validate_held_keys_rejects_duplicate_key() {
+        let err = validate_held_keys(&["Space".to_string(), "Space".to_string()]).unwrap_err();
+
+        assert!(
+            err.message.contains("Duplicate held key: 'Space'"),
             "got: {}",
             err.message
         );

--- a/tests/bdd.rs
+++ b/tests/bdd.rs
@@ -299,6 +299,7 @@ struct CliWorld {
     fixture_path: Option<PathBuf>,
     large_fixture_path: Option<PathBuf>,
     frame_guidance_commands: Vec<String>,
+    temp_home: Option<tempfile::TempDir>,
 }
 
 #[derive(Debug, Clone)]
@@ -347,14 +348,19 @@ fn run_agentchrome(
         &parts[..]
     };
 
-    let unique = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|duration| duration.as_nanos())
-        .unwrap_or_default();
-    let isolated_home = std::env::temp_dir().join(format!(
-        "agentchrome-bdd-cli-{}-{unique}",
-        std::process::id()
-    ));
+    let (isolated_home, remove_home) = if let Some(temp_home) = world.temp_home.as_ref() {
+        (temp_home.path().to_path_buf(), false)
+    } else {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|duration| duration.as_nanos())
+            .unwrap_or_default();
+        let isolated_home = std::env::temp_dir().join(format!(
+            "agentchrome-bdd-cli-{}-{unique}",
+            std::process::id()
+        ));
+        (isolated_home, true)
+    };
     let _ = std::fs::create_dir_all(&isolated_home);
 
     let mut command = std::process::Command::new(binary);
@@ -381,12 +387,22 @@ fn run_agentchrome(
         .wait_with_output()
         .unwrap_or_else(|e| panic!("Failed to wait for {}: {e}", binary.display()));
 
-    let _ = std::fs::remove_dir_all(&isolated_home);
+    if remove_home {
+        let _ = std::fs::remove_dir_all(&isolated_home);
+    }
 
     CommandCapture {
         stdout: String::from_utf8_lossy(&output.stdout).to_string(),
         stderr: String::from_utf8_lossy(&output.stderr).to_string(),
         exit_code: output.status.code().unwrap_or(-1),
+    }
+}
+
+impl Drop for CliWorld {
+    fn drop(&mut self) {
+        if self.binary_path.is_some() && self.temp_home.is_some() {
+            let _ = run_agentchrome(self, "agentchrome connect --disconnect", None);
+        }
     }
 }
 
@@ -587,6 +603,173 @@ fn stderr_should_contain(world: &mut CliWorld, expected: String) {
         "stderr does not contain '{expected}'\nstderr: {}",
         world.stderr
     );
+}
+
+#[given("Chrome is running with CDP enabled")]
+fn cli_chrome_running(world: &mut CliWorld) {
+    agentchrome_is_built(world);
+    if world.temp_home.is_none() {
+        world.temp_home =
+            Some(tempfile::tempdir().expect("failed to create isolated CliWorld home"));
+    }
+
+    let capture = run_agentchrome(world, "agentchrome connect --launch --headless", None);
+    assert_eq!(
+        capture.exit_code, 0,
+        "failed to launch Chrome\nstdout: {}\nstderr: {}",
+        capture.stdout, capture.stderr
+    );
+}
+
+#[given("the click held-keys fixture is loaded")]
+fn click_held_keys_fixture_loaded(world: &mut CliWorld) {
+    let fixture = project_root().join("tests/fixtures/click-held-keys.html");
+    assert!(fixture.is_file(), "missing fixture {}", fixture.display());
+    let capture = run_agentchrome(
+        world,
+        &format!(
+            "agentchrome navigate file://{} --wait-until networkidle",
+            fixture.display()
+        ),
+        None,
+    );
+    assert_eq!(
+        capture.exit_code, 0,
+        "failed to load fixture\nstdout: {}\nstderr: {}",
+        capture.stdout, capture.stderr
+    );
+}
+
+#[given("a snapshot has been taken with UIDs assigned")]
+fn cli_snapshot_taken(world: &mut CliWorld) {
+    let capture = run_agentchrome(world, "agentchrome page snapshot --compact", None);
+    assert_eq!(
+        capture.exit_code, 0,
+        "failed to take snapshot\nstdout: {}\nstderr: {}",
+        capture.stdout, capture.stderr
+    );
+    world.stdout = capture.stdout;
+    world.stderr = capture.stderr;
+    world.exit_code = Some(capture.exit_code);
+}
+
+#[given(expr = "the page has a button with snapshot UID {string}")]
+fn page_has_button_uid(world: &mut CliWorld, uid: String) {
+    assert!(
+        world.stdout.contains(&format!("[{uid}]")),
+        "snapshot does not contain UID {uid}\nsnapshot: {}",
+        world.stdout
+    );
+}
+
+#[then(expr = "the output JSON should contain {string} equal to {string}")]
+fn output_json_string_field_equals(world: &mut CliWorld, field: String, expected: String) {
+    let json = stdout_json(world);
+    assert_eq!(
+        json_pointer(&json, &field),
+        JsonValue::String(expected.clone()),
+        "expected stdout JSON field {field} to equal {expected}\nstdout: {}",
+        world.stdout
+    );
+}
+
+#[then(expr = "the output JSON should contain {string} equal to {word}")]
+fn output_json_word_field_equals(world: &mut CliWorld, field: String, expected: String) {
+    let json = stdout_json(world);
+    let expected_json = match expected.as_str() {
+        "true" => JsonValue::Bool(true),
+        "false" => JsonValue::Bool(false),
+        _ => JsonValue::String(expected.clone()),
+    };
+    assert_eq!(
+        json_pointer(&json, &field),
+        expected_json,
+        "expected stdout JSON field {field} to equal {expected}\nstdout: {}",
+        world.stdout
+    );
+}
+
+#[then(expr = "the output JSON {string} should be {float}")]
+fn output_json_number_field_equals(world: &mut CliWorld, field: String, expected: f64) {
+    let json = stdout_json(world);
+    let actual = json_pointer(&json, &field);
+    let actual = actual
+        .as_f64()
+        .unwrap_or_else(|| panic!("field {field} is not a number in stdout: {}", world.stdout));
+    assert!(
+        (actual - expected).abs() < f64::EPSILON,
+        "expected stdout JSON field {field} to equal {expected}, got {actual}\nstdout: {}",
+        world.stdout
+    );
+}
+
+#[then(expr = "the click event log should show {string}")]
+fn click_event_log_should_show(world: &mut CliWorld, expected: String) {
+    let events = click_event_log(world);
+    let actual = events
+        .iter()
+        .map(|event| {
+            let event_type = event["type"].as_str().unwrap_or_default();
+            let label = if event_type == "click" {
+                event["target"].as_str().unwrap_or_default().to_string()
+            } else {
+                normalize_event_key(event["key"].as_str().unwrap_or_default())
+            };
+            format!("{event_type}:{label}")
+        })
+        .collect::<Vec<_>>()
+        .join(",");
+    assert_eq!(actual, expected, "event log mismatch: {events:?}");
+}
+
+#[then(expr = "the click event log should contain {string} with {string} equal to true")]
+fn click_event_log_should_contain_true(world: &mut CliWorld, event_type: String, field: String) {
+    let events = click_event_log(world);
+    let event = events
+        .iter()
+        .find(|event| event["type"].as_str() == Some(event_type.as_str()))
+        .unwrap_or_else(|| panic!("missing {event_type} event in log: {events:?}"));
+    assert_eq!(
+        event[&field],
+        JsonValue::Bool(true),
+        "expected {event_type}.{field} to be true in log: {events:?}"
+    );
+}
+
+fn json_pointer(json: &JsonValue, dotted_path: &str) -> JsonValue {
+    dotted_path
+        .split('.')
+        .try_fold(json, |current, segment| current.get(segment))
+        .unwrap_or(&JsonValue::Null)
+        .clone()
+}
+
+fn click_event_log(world: &mut CliWorld) -> Vec<JsonValue> {
+    let capture = run_agentchrome(
+        world,
+        "agentchrome js exec JSON.stringify(window.AGENTCHROME_CLICK_EVENTS)",
+        None,
+    );
+    assert_eq!(
+        capture.exit_code, 0,
+        "failed to read click event log\nstdout: {}\nstderr: {}",
+        capture.stdout, capture.stderr
+    );
+    let outer: JsonValue = serde_json::from_str(capture.stdout.trim())
+        .unwrap_or_else(|e| panic!("js stdout is not JSON: {e}\nstdout: {}", capture.stdout));
+    let result = outer["result"]
+        .as_str()
+        .unwrap_or_else(|| panic!("js stdout missing string result: {}", capture.stdout));
+    serde_json::from_str(result)
+        .unwrap_or_else(|e| panic!("event log result is not JSON: {e}\nresult: {result}"))
+}
+
+fn normalize_event_key(key: &str) -> String {
+    if key == " " {
+        "Space".to_string()
+    } else {
+        key.to_string()
+    }
 }
 
 #[then(expr = "stderr should not contain {string}")]
@@ -5131,6 +5314,7 @@ const INTERACT_TESTABLE_SCENARIOS: &[&str] = &[
     "Double and right flags are mutually exclusive",
     "Interact help displays all subcommands",
     "Click help displays all options",
+    "Duplicate held click keys are rejected",
 ];
 
 /// Wait-until click BDD scenarios that can be tested without a running Chrome instance.

--- a/tests/bdd.rs
+++ b/tests/bdd.rs
@@ -400,8 +400,15 @@ fn run_agentchrome(
 
 impl Drop for CliWorld {
     fn drop(&mut self) {
-        if self.binary_path.is_some() && self.temp_home.is_some() {
-            let _ = run_agentchrome(self, "agentchrome connect --disconnect", None);
+        if let (Some(binary), Some(temp_home)) = (&self.binary_path, &self.temp_home) {
+            let _ = std::process::Command::new(binary)
+                .args(["connect", "--disconnect"])
+                .env("HOME", temp_home.path())
+                .env("USERPROFILE", temp_home.path())
+                .env("AGENTCHROME_NO_SKILL_CHECK", "1")
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .status();
         }
     }
 }
@@ -696,8 +703,9 @@ fn output_json_number_field_equals(world: &mut CliWorld, field: String, expected
     let actual = actual
         .as_f64()
         .unwrap_or_else(|| panic!("field {field} is not a number in stdout: {}", world.stdout));
+    const TOLERANCE: f64 = 1e-9;
     assert!(
-        (actual - expected).abs() < f64::EPSILON,
+        (actual - expected).abs() < TOLERANCE,
         "expected stdout JSON field {field} to equal {expected}, got {actual}\nstdout: {}",
         world.stdout
     );

--- a/tests/bdd.rs
+++ b/tests/bdd.rs
@@ -698,12 +698,13 @@ fn output_json_word_field_equals(world: &mut CliWorld, field: String, expected: 
 
 #[then(expr = "the output JSON {string} should be {float}")]
 fn output_json_number_field_equals(world: &mut CliWorld, field: String, expected: f64) {
+    const TOLERANCE: f64 = 1e-9;
+
     let json = stdout_json(world);
     let actual = json_pointer(&json, &field);
     let actual = actual
         .as_f64()
         .unwrap_or_else(|| panic!("field {field} is not a number in stdout: {}", world.stdout));
-    const TOLERANCE: f64 = 1e-9;
     assert!(
         (actual - expected).abs() < TOLERANCE,
         "expected stdout JSON field {field} to equal {expected}, got {actual}\nstdout: {}",

--- a/tests/features/interact.feature
+++ b/tests/features/interact.feature
@@ -57,7 +57,14 @@ Feature: Mouse Interactions
     Then the exit code should be 0
     And stdout should contain "--double"
     And stdout should contain "--right"
+    And stdout should contain "--hold"
     And stdout should contain "--include-snapshot"
+
+  Scenario: Duplicate held click keys are rejected
+    Given agentchrome is built
+    When I run "agentchrome interact click s1 --hold Space --hold Space"
+    Then the exit code should be nonzero
+    And stderr should contain "Duplicate held key"
 
   # --- Click: Happy Paths (require Chrome) ---
 
@@ -134,6 +141,28 @@ Feature: Mouse Interactions
     When I run "agentchrome interact click-at 100 200 --double"
     Then the output JSON should contain "double_click" equal to true
     And the output JSON "clicked_at.x" should be 100
+
+  # Added by issue #291
+  Scenario: Shift-click an element
+    Given Chrome is running with CDP enabled
+    And the click held-keys fixture is loaded
+    And a snapshot has been taken with UIDs assigned
+    And the page has a button with snapshot UID "s1"
+    When I run "agentchrome interact click s1 --hold Shift"
+    Then the output JSON should contain "clicked" equal to "s1"
+    And the click event log should show "keydown:Shift,click:target,keyup:Shift"
+    And the click event log should contain "click" with "shiftKey" equal to true
+    And the exit code should be 0
+
+  # Added by issue #291
+  Scenario: Hold arbitrary key during coordinate click
+    Given Chrome is running with CDP enabled
+    And the click held-keys fixture is loaded
+    When I run "agentchrome interact click-at 100 200 --hold Space --hold Alt"
+    Then the output JSON "clicked_at.x" should be 100
+    And the click event log should show "keydown:Space,keydown:Alt,click:pad,keyup:Alt,keyup:Space"
+    And the click event log should contain "click" with "altKey" equal to true
+    And the exit code should be 0
 
   # --- Hover ---
 

--- a/tests/fixtures/click-held-keys.html
+++ b/tests/fixtures/click-held-keys.html
@@ -1,0 +1,74 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Click Held Keys Fixture</title>
+    <style>
+      body {
+        font-family: system-ui, sans-serif;
+        margin: 32px;
+        min-height: 420px;
+      }
+
+      #target,
+      #pad {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 220px;
+        height: 96px;
+        margin-right: 16px;
+        border: 2px solid #246;
+        background: #eef7ff;
+      }
+
+      #pad {
+        position: absolute;
+        left: 32px;
+        top: 160px;
+      }
+
+      #events {
+        margin-top: 180px;
+        min-height: 180px;
+        padding: 12px;
+        border: 1px solid #bbb;
+        background: #f7f7f7;
+        white-space: pre-wrap;
+      }
+    </style>
+  </head>
+  <body>
+    <button id="target" type="button">Held-key target</button>
+    <div id="pad" role="button" tabindex="0">Coordinate pad</div>
+    <pre id="events">[]</pre>
+    <script>
+      window.AGENTCHROME_CLICK_EVENTS = [];
+
+      function record(event) {
+        window.AGENTCHROME_CLICK_EVENTS.push({
+          type: event.type,
+          key: event.key || null,
+          target: event.target.id || event.target.tagName.toLowerCase(),
+          altKey: event.altKey,
+          ctrlKey: event.ctrlKey,
+          metaKey: event.metaKey,
+          shiftKey: event.shiftKey,
+        });
+        document.getElementById("events").textContent = JSON.stringify(
+          window.AGENTCHROME_CLICK_EVENTS,
+          null,
+          2
+        );
+      }
+
+      for (const type of ["keydown", "keyup"]) {
+        document.addEventListener(type, record, true);
+      }
+
+      for (const target of [document.getElementById("target"), document.getElementById("pad")]) {
+        target.addEventListener("click", record);
+      }
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary

- Adds repeatable `--hold <KEY>` support to `interact click` and `interact click-at` so click automation can model modifier-sensitive and held-key interactions from the mouse-interactions spec.
- Wraps click dispatch with keyDown/click/keyUp lifecycle handling, including CDP mouse modifier bits for `Alt`, `Control`, `Meta`, and `Shift`, plus cleanup on click errors.
- Adds help/examples, man page updates, BDD coverage, unit coverage, a deterministic held-key fixture, and a verification report for issue #291.

## Acceptance Criteria

From `specs/feature-mouse-interactions/requirements.md`:

- [x] AC23: Hold Shift while clicking an element
- [x] AC24: Hold any supported key during coordinate clicks
- [x] AC25: Existing click behavior is preserved when held keys are omitted
- [x] AC26: Invalid or duplicate held keys are rejected

## Test Plan

From `specs/feature-mouse-interactions/tasks.md` testing phase:

- [x] Build: `cargo build`
- [x] Unit tests: `cargo test --lib`
- [x] BDD tests: `cargo test --test bdd`
- [x] Lint: `cargo clippy --all-targets`
- [x] Format: `cargo fmt --check`
- [x] Feature exercise: headless AgentChrome smoke against `tests/fixtures/click-held-keys.html` for `--hold Shift`, `--hold Space --hold Alt`, invalid/duplicate held keys, unheld click regression, and disconnect cleanup

## Specs

- Requirements: `specs/feature-mouse-interactions/requirements.md`
- Design: `specs/feature-mouse-interactions/design.md`
- Tasks: `specs/feature-mouse-interactions/tasks.md`
- Verification: `specs/feature-mouse-interactions/verification-report.md`

Closes #291

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--hold` option to click commands, allowing one or more keyboard keys to be held during click dispatch.

* **Documentation**
  * Updated command documentation across all `interact` subcommands to describe the new `--hold` option with examples for single and multiple held keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->